### PR TITLE
Users can now specify a prompt

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -92,22 +92,21 @@ Key configuration groups:
 
 ## Prompt System
 
-Three key prompts:
+Two key prompts:
 
 1. frame_analysis.txt
    - Analyzes single frame
    - Includes timestamp context
    - Focuses on visual elements and actions
 
-2. video_reconstruction.txt
+2. describe.txt
    - Combines frame analyses
+   - uses 1 frame
    - Integrates transcript
-   - Creates chronological description
+   - Creates a description of the video based on all the past frames
 
-3. narrate_storyteller.txt
-   - Transforms technical description
-   - Makes narrative more engaging
-   - Maintains factual accuracy
+## Sample output
+[Sample Output](sample_analysis.json)
 
 ## Common Issues & Solutions
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -98,12 +98,16 @@ Two key prompts:
    - Analyzes single frame
    - Includes timestamp context
    - Focuses on visual elements and actions
+   - Supports user questions through {prompt} token
 
 2. describe.txt
    - Combines frame analyses
-   - uses 1 frame
+   - Uses 1 frame
    - Integrates transcript
    - Creates a description of the video based on all the past frames
+   - Supports user questions through {prompt} token
+
+Both prompts support user questions via the --prompt flag. When a question is provided, it is prefixed with "I want to know" and injected into the prompts using the {prompt} token. This allows users to ask specific questions about the video that guide both the frame analysis and final description.
 
 ## Sample output
 [Sample Output](sample_analysis.json)

--- a/docs/sample_analysis.json
+++ b/docs/sample_analysis.json
@@ -1,0 +1,118 @@
+{
+  "metadata": {
+    "client": "ollama",
+    "model": "llama3.2-vision",
+    "whisper_model": "medium",
+    "frames_per_minute": 60,
+    "duration_processed": null,
+    "frames_extracted": 5,
+    "frames_processed": 5,
+    "start_stage": 1,
+    "audio_language": "en",
+    "transcription_successful": true
+  },
+  "transcript": {
+    "text": " I'm scared!",
+    "segments": [
+      {
+        "text": " I'm scared!",
+        "start": 1.78,
+        "end": 2.24,
+        "words": [
+          {
+            "word": " I'm",
+            "start": 1.78,
+            "end": 2.04,
+            "probability": 0.4382356107234955
+          },
+          {
+            "word": " scared!",
+            "start": 2.04,
+            "end": 2.24,
+            "probability": 0.9464112520217896
+          }
+        ]
+      }
+    ]
+  },
+  "frame_analyses": [
+    {
+      "model": "llama3.2-vision",
+      "created_at": "2024-12-18T23:14:35.871404545Z",
+      "response": "Frame 0\n\nSetting/Scene: A person with long blonde hair, wearing a pink t-shirt and yellow shorts, stands in front of a black plastic tub or container on wheels. The ground appears to be covered in wood chips.\n\nAction/Movement: The person is facing away from the camera, looking down at something inside the tub. Their left hand is resting on their hip, while their right arm hangs loosely by their side.\n\nNew Information: There are no new objects or people visible in this frame. However, there appears to be some greenery and possibly fruit scattered around the ground behind the person.\n\nContinuity Points:\n\n* The person's pink t-shirt matches the color of the shirt worn by the person in the background of Frame 1.\n* The black plastic tub on wheels is also present in Frame 1.\n* The wood chips covering the ground are consistent with those seen in Frame 1.\n\nKey Continuation Point: Watch for the person to pick up an object from the tub and examine it more closely.",
+      "done": true,
+      "done_reason": "stop",
+      "total_duration": 7952576674,
+      "load_duration": 2623794964,
+      "prompt_eval_count": 349,
+      "prompt_eval_duration": 1787000000,
+      "eval_count": 207,
+      "eval_duration": 3317000000
+    },
+    {
+      "model": "llama3.2-vision",
+      "created_at": "2024-12-18T23:14:41.664468523Z",
+      "response": "Frame 1\n\nSetting/Scene: A person with long blonde hair, wearing a pink t-shirt and yellow shorts, stands in front of a black plastic tub or container on wheels. The ground appears to be covered in wood chips.\n\nAction/Movement: The person is facing away from the camera, looking down at something inside the tub. Their left hand is resting on their hip, while their right arm hangs loosely by their side.\n\nNew Information: There are no new objects or people visible in this frame. However, there appears to be some greenery and possibly fruit scattered around the ground behind the person.\n\nContinuity Points:\n\n* The person's pink t-shirt matches the color of the shirt worn by the person in Frame 0.\n* The black plastic tub on wheels is also present in Frame 0.\n* The wood chips covering the ground are consistent with those seen in Frame 0.\n\nKey Continuation Point: Watch for the person to pick up an object from the tub and examine it more closely.",
+      "done": true,
+      "done_reason": "stop",
+      "total_duration": 5451905730,
+      "load_duration": 15567833,
+      "prompt_eval_count": 559,
+      "prompt_eval_duration": 1810000000,
+      "eval_count": 204,
+      "eval_duration": 3408000000
+    },
+    {
+      "model": "llama3.2-vision",
+      "created_at": "2024-12-18T23:14:47.516490633Z",
+      "response": "**Frame 2**\n\n*   **Setting/Scene**: The person with long blonde hair, wearing a pink t-shirt and yellow shorts, stands in front of a black plastic tub or container on wheels. The ground appears to be covered in wood chips.\n*   **Action/Movement**: The person is facing away from the camera, looking down at something inside the tub. Their left hand is resting on their hip, while their right arm hangs loosely by their side.\n*   **New Information**: There are no new objects or people visible in this frame. However, there appears to be some greenery and possibly fruit scattered around the ground behind the person.\n*   **Continuity Points**:\n    *   The person's pink t-shirt matches the color of the shirt worn by the person in Frame 0.\n    *   The black plastic tub on wheels is also present in Frame 0.\n    *   The wood chips covering the ground are consistent with those seen in Frame 0.\n*   **Key Continuation Point**: Watch for the person to pick up an object from the tub and examine it more closely.",
+      "done": true,
+      "done_reason": "stop",
+      "total_duration": 5848181203,
+      "load_duration": 14482916,
+      "prompt_eval_count": 766,
+      "prompt_eval_duration": 1798000000,
+      "eval_count": 227,
+      "eval_duration": 3823000000
+    },
+    {
+      "model": "llama3.2-vision",
+      "created_at": "2024-12-18T23:14:54.869592761Z",
+      "response": "**Frame Description**\n\n* **Setting/Scene**: The person with long blonde hair, wearing a pink t-shirt and yellow shorts, stands in front of a black plastic tub or container on wheels. The ground appears to be covered in wood chips.\n* **Action/Movement**: The person is facing away from the camera, looking down at something inside the tub. Their left hand is resting on their hip, while their right arm hangs loosely by their side.\n* **New Information**: There are no new objects or people visible in this frame. However, there appears to be some greenery and possibly fruit scattered around the ground behind the person.\n* **Continuity Points**:\n\t+ The person's pink t-shirt matches the color of the shirt worn by the person in Frame 0.\n\t+ The black plastic tub on wheels is also present in Frame 0.\n\t+ The wood chips covering the ground are consistent with those seen in Frame 0.\n* **Key Continuation Point**: Watch for the person to pick up an object from the tub and examine it more closely.\n\n**Writing Guidelines**\n\n* Use present tense\n* Be specific and concise\n* Avoid interpretation - stick to what you can see\n* Use clear transitional phrases to connect to previous descriptions\n* Include timestamp if available\n\n**Format Your Notes As**\n\n```\nFrame 3 (5.10 seconds)\n[Your observations following the structure above]\nKey continuation points:\n- [List 2-3 elements that the next viewer",
+      "done": true,
+      "done_reason": "length",
+      "total_duration": 7348923526,
+      "load_duration": 14771659,
+      "prompt_eval_count": 996,
+      "prompt_eval_duration": 1915000000,
+      "eval_count": 301,
+      "eval_duration": 5193000000
+    },
+    {
+      "model": "llama3.2-vision",
+      "created_at": "2024-12-18T23:15:02.285939575Z",
+      "response": "**Frame Description**\n\n* **Setting/Scene**: The person with long blonde hair, wearing a pink t-shirt and yellow shorts, stands in front of a black plastic tub or container on wheels. The ground appears to be covered in wood chips.\n* **Action/Movement**: The person is facing away from the camera, looking down at something inside the tub. Their left hand is resting on their hip, while their right arm hangs loosely by their side.\n* **New Information**: There are no new objects or people visible in this frame. However, there appears to be some greenery and possibly fruit scattered around the ground behind the person.\n* **Continuity Points**:\n\t+ The person's pink t-shirt matches the color of the shirt worn by the person in Frame 0.\n\t+ The black plastic tub on wheels is also present in Frame 0.\n\t+ The wood chips covering the ground are consistent with those seen in Frame 0.\n* **Key Continuation Point**: Watch for the person to pick up an object from the tub and examine it more closely.\n\n**Writing Guidelines**\n\n* Use present tense\n* Be specific and concise\n* Avoid interpretation - stick to what you can see\n* Use clear transitional phrases to connect to previous descriptions\n* Include timestamp if available\n\n**Format Your Notes As**\n\n```\nFrame 4 (5.67 seconds)\n[Your observations following the structure above]\nKey continuation points:\n- [List 2-3 elements that the next viewer",
+      "done": true,
+      "done_reason": "length",
+      "total_duration": 7412131422,
+      "load_duration": 14780998,
+      "prompt_eval_count": 1302,
+      "prompt_eval_duration": 2047000000,
+      "eval_count": 301,
+      "eval_duration": 5137000000
+    }
+  ],
+  "video_description": {
+    "model": "llama3.2-vision",
+    "created_at": "2024-12-18T23:15:06.166299111Z",
+    "response": "**Video Summary**\n\nDuration: 5 minutes and 67 seconds\n\nThe video begins with a person with long blonde hair, wearing a pink t-shirt and yellow shorts, standing in front of a black plastic tub or container on wheels. The ground appears to be covered in wood chips.\n\nAs the video progresses, the person remains facing away from the camera, looking down at something inside the tub. Their left hand is resting on their hip, while their right arm hangs loosely by their side. There are no new objects or people visible in this frame, but there appears to be some greenery and possibly fruit scattered around the ground behind the person.\n\nThe black plastic tub on wheels is present throughout the video, and the wood chips covering the ground remain consistent with those seen in Frame 0. The person's pink t-shirt matches the color of the shirt worn by the person in Frame 0.\n\nAs the video continues, the person remains stationary, looking down at something inside the tub. There are no significant changes or developments in this frame.\n\nThe key continuation point is to watch for the person to pick up an object from the tub and examine it more closely.\n\n**Key Continuation Points:**\n\n*   The person's pink t-shirt matches the color of the shirt worn by the person in Frame 0.\n*   The black plastic tub on wheels is also present in Frame 0.\n*   The wood chips covering the ground are consistent with those seen in Frame 0.",
+    "done": true,
+    "done_reason": "stop",
+    "total_duration": 3877694027,
+    "load_duration": 10604604,
+    "prompt_eval_count": 1705,
+    "prompt_eval_duration": 558000000,
+    "eval_count": 297,
+    "eval_duration": 3308000000
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -145,28 +145,7 @@ video-analyzer path/to/video.mp4 --openrouter-key your-api-key
 
 #### Sample Output
 ```
-Transcript:
- Happy birthday to you!
-
-Enhanced Video Narrative:
-Here are the descriptions of what's happening in each frame:
-
-**Frame 1 (2.50s)**
-A woman enters a bedroom with a tray of breakfast items. She is wearing a white robe and holding a wooden tray, accompanied by a young girl with blonde hair who is smiling.
-
-**To Frame 2 (4.50s)**
-The woman moves to the right side of the image, still holding the tray of food and drinks. The young girl looks up at something outside the frame, while two other young girls with blue hoodies stand behind the woman, all smiling.
-
-**To Frame 3 (5.00s)**
-The woman holds the tray of food and drinks in front of the camera, with the two young girls with blue hoodies standing behind her. The food and drinks on the tray are assorted colors.
-
-**To Frame 4 (5.50s)**
-The woman moves slightly to the right and now holds the tray in front of a bunk bed. A blue curtain is visible behind the bunk bed, and she is wearing a white jacket.
-
-**To Frame 5 (6.00s)**
-The woman holds the tray in the center of the image, with a bed with a pink pillow visible against the wall to her right. She is now wearing a white shirt.
-
-Note: The audio transcript indicates that "Happy Birthday to You!" is being sung, suggesting that this scene is taking place during a birthday celebration.
+Video Summary**\n\nDuration: 5 minutes and 67 seconds\n\nThe video begins with a person with long blonde hair, wearing a pink t-shirt and yellow shorts, standing in front of a black plastic tub or container on wheels. The ground appears to be covered in wood chips.\n\nAs the video progresses, the person remains facing away from the camera, looking down at something inside the tub. Their left hand is resting on their hip, while their right arm hangs loosely by their side. There are no new objects or people visible in this frame, but there appears to be some greenery and possibly fruit scattered around the ground behind the person.\n\nThe black plastic tub on wheels is present throughout the video, and the wood chips covering the ground remain consistent with those seen in Frame 0. The person's pink t-shirt matches the color of the shirt worn by the person in Frame 0.\n\nAs the video continues, the person remains stationary, looking down at something inside the tub. There are no significant changes or developments in this frame.\n\nThe key continuation point is to watch for the person to pick up an object from the tub and examine it more closely.\n\n**Key Continuation Points:**\n\n*   The person's pink t-shirt matches the color of the shirt worn by the person in Frame 0.\n*   The black plastic tub on wheels is also present in Frame 0.\n*   The wood chips covering the ground are consistent with those seen in Frame 0.
 ```
 
 ### Advanced Usage
@@ -249,59 +228,6 @@ The tool generates a JSON file (`analysis.json`) containing:
 
 ### Example Output Structure
 
-```json
-{
-  "metadata": {
-    "client": "openrouter",
-    "model": "meta-llama/llama-3.2-11b-vision-instruct:free",
-    "whisper_model": "medium",
-    "frames_per_minute": 60,
-    "duration_processed": null,
-    "frames_extracted": 8,
-    "frames_processed": 8,
-    "start_stage": 1,
-    "audio_language": "en",
-    "transcription_successful": true
-  },
-  "transcript": {
-    "text": " I've ever tasted. Good, I'm so happy. I'm glad we did the hot cocoa bombs. It's the  sugary-est though. I'm so glad we got her the hot cocoa.",
-    "segments": [
-      {
-        "text": " I've ever tasted. Good, I'm so happy. I'm glad we did the hot cocoa bombs. It's the",
-        "start": 0.0,
-        "end": 6.32,
-        "words": [
-          {
-            "word": " I've",
-            "start": 0.0,
-            "end": 0.26,
-            "probability": 0.22717513144016266
-          },
-          ...
-          {
-            "word": " the",
-            "start": 6.12,
-            "end": 6.32,
-            "probability": 0.34964463114738464
-          }
-        ]
-      }
-    ]
-  },
-  "frame_analyses": [
-    {
-      "response": "Frame 0\nThe scene is set in a snowy environment, with a person wearing a light blue hoodie and black pants standing in front of a building. The person is facing away from the camera, and their head is covered with a black and white patterned hat.\n\nAction/Movement\nThe person is standing still, with their arms at their sides. There is no visible movement or action in this frame.\n\nNew Information\nThere are no new objects, people, or text visible in this frame. The background is blurry, but it appears to be a building with windows and a door.\n\nContinuity Points\nThis frame does not provide any continuity points to previous frames, as it is the first frame in the sequence.\n\nKey Continuation Points:\n- The person's clothing and accessories, such as the hat and hoodie, may be important to note for future frames.\n- The building in the background may be a significant location in the narrative.\n- The snowy environment may be a recurring theme throughout the video."
-    },
-    ...
-    {
-      "response": "Frame 7 (8.00 seconds)\nSetting/Scene: The snowy environment remains the same, with the building in the background still blurry.\n\nAction/Movement: The person is now walking towards the camera, their pace slightly faster than before. They are looking directly at the camera, and their facial expression appears neutral.\n\nNew Information: There are no new objects, people, or text visible in this frame. The audio remains the same as previous frames.\n\nContinuity Points: The person's clothing and accessories, as well as the building in the background, are consistent with previous frames. The snowy environment continues to be a significant part of the scene.\n\nKey Continuation Points:\n- The direction of the person's movement may indicate a destination or a goal.\n- The person's facial expression and body language may change as they approach the camera.\n- The steady pace of the person's movement may suggest a sense of purpose or urgency."
-    }
-  ],
-  "video_description": {
-    "response": "Here is a synthesized video summary based on the provided frame descriptions:\n\n**VIDEO SUMMARY**\n\nDuration: 8 seconds\n\n**Opening Description**\n\nThe video begins with a person standing in a snowy environment, wearing a light blue hoodie and black pants, with a black and white patterned hat covering their head. They are facing away from the camera, with their arms at their sides, and standing in front of a blurry building with windows and a door. The initial tone and context suggest a serene and peaceful atmosphere.\n\n**Narrative Development**\n\nAs the person turns to face the camera in Frame 1, their gaze is directed towards the camera, and their body is slightly turned to the right. This subtle movement sets the stage for their deliberate and purposeful actions throughout the video. In subsequent frames, the person walks towards the camera, their pace steady and purposeful, with their arms still at their sides. Their facial expression remains neutral, but their gaze is fixed on the camera, suggesting a sense of focus or interest. The direction of their movement may indicate a destination or goal, and the steady pace of their movement suggests a sense of purpose or urgency.\n\n**Technical Elements**\n\nThe camera appears to be stationary, with no notable movements described. The editing transitions are not explicitly mentioned, but the seamless progression from one frame to the next suggests a smooth and natural cut. The visual effects are minimal, with no notable changes in lighting or composition.\n\n**Closing Observations**\n\nThe video concludes with the person walking towards the camera, their pace slightly faster than before, and their gaze fixed on the camera. The final state of the scene is one of purposeful movement, with the person seemingly focused on a specific destination or goal. The narrative is coherent and engaging, with a clear progression from the initial setting to the final state.\n\nNote: This summary is based on direct observation of the first frame combined with detailed notes from subsequent frames."
-  }
-}
-```
 
 ## Uninstallation
 

--- a/video_analyzer/cli.py
+++ b/video_analyzer/cli.py
@@ -75,6 +75,8 @@ def main():
     parser.add_argument("--log-level", type=str, default="INFO", 
                         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
                         help="Set the logging level (default: INFO)")
+    parser.add_argument("--prompt", type=str, default="",
+                        help="Question to ask about the video")
     args = parser.parse_args()
 
     # Set up logging with specified level
@@ -135,7 +137,7 @@ def main():
         # Stage 2: Frame Analysis
         if args.start_stage <= 2:
             logger.info("Analyzing frames...")
-            analyzer = VideoAnalyzer(client, model, prompt_loader)
+            analyzer = VideoAnalyzer(client, model, prompt_loader, config.get("prompt", ""))
             frame_analyses = []
             for frame in frames:
                 analysis = analyzer.analyze_frame(frame)

--- a/video_analyzer/config.py
+++ b/video_analyzer/config.py
@@ -72,6 +72,8 @@ class Config:
                 elif key == "model":
                     client = self.config["clients"]["default"]
                     self.config["clients"][client]["model"] = value
+                elif key == "prompt":
+                    self.config["prompt"] = value
                 elif key not in ["start_stage", "max_frames"]:  # Ignore these as they're command-line only
                     self.config[key] = value
 

--- a/video_analyzer/config/default_config.json
+++ b/video_analyzer/config/default_config.json
@@ -43,5 +43,6 @@
         "chunk_length": 30,
         "language_confidence_threshold": 0.8
     },
-    "keep_frames": false
+    "keep_frames": false,
+    "prompt": ""
 }

--- a/video_analyzer/prompts/frame_analysis/describe.txt
+++ b/video_analyzer/prompts/frame_analysis/describe.txt
@@ -81,6 +81,8 @@ Technical terms are used correctly
 The opening matches your viewed frame
 Transitions between described frames feel natural
 
+{prompt}
+
 Format Your Summary As:
 
 ```

--- a/video_analyzer/prompts/frame_analysis/frame_analysis.txt
+++ b/video_analyzer/prompts/frame_analysis/frame_analysis.txt
@@ -4,7 +4,7 @@ Previous Notes Section
 
 {PREVIOUS_FRAMES}
 
-Your Task
+Your Tasks
 You are viewing Frame [X] of this video sequence. Your goal is to document what you observe in a way that contributes to a coherent narrative of the entire video.
 Step 1: Quick Scan
 
@@ -51,6 +51,8 @@ Be specific and concise
 Avoid interpretation - stick to what you can see
 Use clear transitional phrases to connect to previous descriptions
 Include timestamp if available
+
+{prompt}
 
 Format Your Notes As:
 


### PR DESCRIPTION
user's can now ask questions via the --prompt flag. When a question is provided, it is prefixed with "I want to know" and injected into the prompts using the {prompt} token. This allows users to ask specific questions about the video that guide both the frame analysis and final description.