### PR TITLE
Fix Install Instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.DS_Store

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ cd video-analyzer
 
 2. Create and activate a virtual environment:
 ```bash
-python3 -m venv .venv
+python3.11 -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -126,7 +126,7 @@ video-analyzer/
 │       └── describe.txt
 ├── output/             # Generated during runtime
 ├── video_analyzer/     # Package source code
-└── setup.py           # Package installation configuration
+└── setup.py            # Package installation configuration
 ```
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ torch>=2.0.0
 openai-whisper>=20231117
 requests>=2.31.0
 Pillow>=10.0.0
+pydub>=0.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ openai-whisper>=20231117
 requests>=2.31.0
 Pillow>=10.0.0
 pydub>=0.25.1
+faster-whisper>=0.6.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 # Create data_files list for config and prompts
 data_files = [
-    ('video_analyzer/config', ['config/default_config.json'])
+    ('video_analyzer/config', ['video_analyzer/config/default_config.json'])
 ]
 
 # Recursively add all files from prompts directory


### PR DESCRIPTION
Thanks for this project, it looks awesome! A really cool project.

Had some problems following the install instructions though.

----
Following the install instructions:

```bash
python3 -m venv .venv
pip install .
```

I have python3.13 installed.

```
ERROR: Ignored the following versions that require a different python version: 1.21.2 Requires-Python >=3.7,<3.11; 1.21.3 Requires-Python >=3.7,<3.11; 1.21.4 Requires-Python >=3.7,<3.11; 1.21.5 Requires-Python >=3.7,<3.11; 1.21.6 Requires-Python >=3.7,<3.11; 1.26.0 Requires-Python <3.13,>=3.9; 1.26.1 Requires-Python <3.13,>=3.9
ERROR: Could not find a version that satisfies the requirement torch>=2.0.0 (from video-analyzer) (from versions: none)
ERROR: No matching distribution found for torch>=2.0.0
```

So added the version needed to the readme instructions.

----

Then got this:

```bash
(.venv) kylehowells@Kyles-MBP video-analyzer % pip install .
Processing /Users/kylehowells/Developer/Example-Projects/video-analyzer
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting opencv-python>=4.8.0 (from video-analyzer==0.1.0)
  Using cached opencv_python-4.10.0.84-cp37-abi3-macosx_11_0_arm64.whl.metadata (20 kB)
Collecting numpy>=1.24.0 (from video-analyzer==0.1.0)
  Using cached numpy-2.2.1-cp311-cp311-macosx_14_0_arm64.whl.metadata (62 kB)
Collecting torch>=2.0.0 (from video-analyzer==0.1.0)
  Using cached torch-2.5.1-cp311-none-macosx_11_0_arm64.whl.metadata (28 kB)
Collecting openai-whisper>=20231117 (from video-analyzer==0.1.0)
  Using cached openai_whisper-20240930-py3-none-any.whl
Collecting requests>=2.31.0 (from video-analyzer==0.1.0)
  Using cached requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
Collecting Pillow>=10.0.0 (from video-analyzer==0.1.0)
  Using cached pillow-11.0.0-cp311-cp311-macosx_11_0_arm64.whl.metadata (9.1 kB)
Collecting numba (from openai-whisper>=20231117->video-analyzer==0.1.0)
  Using cached numba-0.60.0-cp311-cp311-macosx_11_0_arm64.whl.metadata (2.7 kB)
Collecting tqdm (from openai-whisper>=20231117->video-analyzer==0.1.0)
  Using cached tqdm-4.67.1-py3-none-any.whl.metadata (57 kB)
Collecting more-itertools (from openai-whisper>=20231117->video-analyzer==0.1.0)
  Using cached more_itertools-10.5.0-py3-none-any.whl.metadata (36 kB)
Collecting tiktoken (from openai-whisper>=20231117->video-analyzer==0.1.0)
  Using cached tiktoken-0.8.0-cp311-cp311-macosx_11_0_arm64.whl.metadata (6.6 kB)
Collecting charset-normalizer<4,>=2 (from requests>=2.31.0->video-analyzer==0.1.0)
  Using cached charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl.metadata (34 kB)
Collecting idna<4,>=2.5 (from requests>=2.31.0->video-analyzer==0.1.0)
  Using cached idna-3.10-py3-none-any.whl.metadata (10 kB)
Collecting urllib3<3,>=1.21.1 (from requests>=2.31.0->video-analyzer==0.1.0)
  Using cached urllib3-2.2.3-py3-none-any.whl.metadata (6.5 kB)
Collecting certifi>=2017.4.17 (from requests>=2.31.0->video-analyzer==0.1.0)
  Using cached certifi-2024.12.14-py3-none-any.whl.metadata (2.3 kB)
Collecting filelock (from torch>=2.0.0->video-analyzer==0.1.0)
  Using cached filelock-3.16.1-py3-none-any.whl.metadata (2.9 kB)
Collecting typing-extensions>=4.8.0 (from torch>=2.0.0->video-analyzer==0.1.0)
  Using cached typing_extensions-4.12.2-py3-none-any.whl.metadata (3.0 kB)
Collecting networkx (from torch>=2.0.0->video-analyzer==0.1.0)
  Using cached networkx-3.4.2-py3-none-any.whl.metadata (6.3 kB)
Collecting jinja2 (from torch>=2.0.0->video-analyzer==0.1.0)
  Using cached jinja2-3.1.5-py3-none-any.whl.metadata (2.6 kB)
Collecting fsspec (from torch>=2.0.0->video-analyzer==0.1.0)
  Using cached fsspec-2024.12.0-py3-none-any.whl.metadata (11 kB)
Collecting sympy==1.13.1 (from torch>=2.0.0->video-analyzer==0.1.0)
  Using cached sympy-1.13.1-py3-none-any.whl.metadata (12 kB)
Collecting mpmath<1.4,>=1.1.0 (from sympy==1.13.1->torch>=2.0.0->video-analyzer==0.1.0)
  Using cached mpmath-1.3.0-py3-none-any.whl.metadata (8.6 kB)
Collecting MarkupSafe>=2.0 (from jinja2->torch>=2.0.0->video-analyzer==0.1.0)
  Using cached MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl.metadata (4.0 kB)
Collecting llvmlite<0.44,>=0.43.0dev0 (from numba->openai-whisper>=20231117->video-analyzer==0.1.0)
  Using cached llvmlite-0.43.0-cp311-cp311-macosx_11_0_arm64.whl.metadata (4.8 kB)
Collecting numpy>=1.24.0 (from video-analyzer==0.1.0)
  Using cached numpy-2.0.2-cp311-cp311-macosx_14_0_arm64.whl.metadata (60 kB)
Collecting regex>=2022.1.18 (from tiktoken->openai-whisper>=20231117->video-analyzer==0.1.0)
  Using cached regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl.metadata (40 kB)
Using cached opencv_python-4.10.0.84-cp37-abi3-macosx_11_0_arm64.whl (54.8 MB)
Using cached pillow-11.0.0-cp311-cp311-macosx_11_0_arm64.whl (3.0 MB)
Using cached requests-2.32.3-py3-none-any.whl (64 kB)
Using cached torch-2.5.1-cp311-none-macosx_11_0_arm64.whl (63.9 MB)
Using cached sympy-1.13.1-py3-none-any.whl (6.2 MB)
Using cached certifi-2024.12.14-py3-none-any.whl (164 kB)
Using cached charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl (118 kB)
Using cached idna-3.10-py3-none-any.whl (70 kB)
Using cached typing_extensions-4.12.2-py3-none-any.whl (37 kB)
Using cached urllib3-2.2.3-py3-none-any.whl (126 kB)
Using cached filelock-3.16.1-py3-none-any.whl (16 kB)
Using cached fsspec-2024.12.0-py3-none-any.whl (183 kB)
Using cached jinja2-3.1.5-py3-none-any.whl (134 kB)
Using cached more_itertools-10.5.0-py3-none-any.whl (60 kB)
Using cached networkx-3.4.2-py3-none-any.whl (1.7 MB)
Using cached numba-0.60.0-cp311-cp311-macosx_11_0_arm64.whl (2.6 MB)
Using cached numpy-2.0.2-cp311-cp311-macosx_14_0_arm64.whl (5.3 MB)
Using cached tiktoken-0.8.0-cp311-cp311-macosx_11_0_arm64.whl (982 kB)
Using cached tqdm-4.67.1-py3-none-any.whl (78 kB)
Using cached llvmlite-0.43.0-cp311-cp311-macosx_11_0_arm64.whl (28.8 MB)
Using cached MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl (12 kB)
Using cached mpmath-1.3.0-py3-none-any.whl (536 kB)
Using cached regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl (284 kB)
Building wheels for collected packages: video-analyzer
  Building wheel for video-analyzer (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for video-analyzer (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [36 lines of output]
      running bdist_wheel
      running build
      running build_py
      copying video_analyzer/config.py -> build/lib/video_analyzer
      copying video_analyzer/analyzer.py -> build/lib/video_analyzer
      copying video_analyzer/__init__.py -> build/lib/video_analyzer
      copying video_analyzer/audio_processor.py -> build/lib/video_analyzer
      copying video_analyzer/cli.py -> build/lib/video_analyzer
      copying video_analyzer/frame.py -> build/lib/video_analyzer
      copying video_analyzer/prompt.py -> build/lib/video_analyzer
      copying video_analyzer/clients/openrouter.py -> build/lib/video_analyzer/clients
      copying video_analyzer/clients/__init__.py -> build/lib/video_analyzer/clients
      copying video_analyzer/clients/llm_client.py -> build/lib/video_analyzer/clients
      copying video_analyzer/clients/ollama.py -> build/lib/video_analyzer/clients
      running egg_info
      writing video_analyzer.egg-info/PKG-INFO
      writing dependency_links to video_analyzer.egg-info/dependency_links.txt
      writing entry points to video_analyzer.egg-info/entry_points.txt
      writing requirements to video_analyzer.egg-info/requires.txt
      writing top-level names to video_analyzer.egg-info/top_level.txt
      reading manifest file 'video_analyzer.egg-info/SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      warning: no files found matching '*' under directory 'config'
      warning: no files found matching '*' under directory 'prompts'
      warning: no previously-included files matching '__pycache__' found anywhere in distribution
      warning: no previously-included files matching '*.py[cod]' found anywhere in distribution
      warning: no previously-included files matching '*.so' found anywhere in distribution
      warning: no previously-included files matching '.DS_Store' found anywhere in distribution
      warning: no previously-included files matching '.git*' found anywhere in distribution
      adding license file 'LICENSE'
      writing manifest file 'video_analyzer.egg-info/SOURCES.txt'
      installing to build/bdist.macosx-14.0-arm64/wheel
      running install
      running install_lib
      running install_data
      error: can't copy 'config/default_config.json': doesn't exist or not a regular file
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for video-analyzer
Failed to build video-analyzer
ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (video-analyzer)
```

Changed setup.py to this fixed it:

```python
# From
data_files = [
    ('video_analyzer/config', ['config/default_config.json'])
]

# To
data_files = [
    ('video_analyzer/config', ['video_analyzer/config/default_config.json'])
]
```

----

Then a successful installation, but running it resulted in:

```bash
(.venv) kylehowells@Kyles-MBP video-analyzer % video-analyzer
Traceback (most recent call last):
  File "/Users/kylehowells/Developer/Example-Projects/video-analyzer/.venv/bin/video-analyzer", line 5, in <module>
    from video_analyzer.cli import main
  File "/Users/kylehowells/Developer/Example-Projects/video-analyzer/.venv/lib/python3.11/site-packages/video_analyzer/cli.py", line 14, in <module>
    from .analyzer import VideoAnalyzer
  File "/Users/kylehowells/Developer/Example-Projects/video-analyzer/.venv/lib/python3.11/site-packages/video_analyzer/analyzer.py", line 6, in <module>
    from .audio_processor import AudioTranscript
  File "/Users/kylehowells/Developer/Example-Projects/video-analyzer/.venv/lib/python3.11/site-packages/video_analyzer/audio_processor.py", line 7, in <module>
    from pydub import AudioSegment
ModuleNotFoundError: No module named 'pydub'
```

So have added `pydub` to the requirements.txt file.


----

Then:

```bash
(.venv) kylehowells@Kyles-MBP video-analyzer % video-analyzer '/Users/kylehowells/Movies/Movies/Making a Desktop Fusion Reactor.mp4'
2024-12-22 03:27:55,379 - ERROR - Error loading Whisper model: No module named 'faster_whisper'
2024-12-22 03:27:55,379 - ERROR - Error during video analysis: No module named 'faster_whisper'
Traceback (most recent call last):
  File "/Users/kylehowells/Developer/Example-Projects/video-analyzer/.venv/bin/video-analyzer", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/kylehowells/Developer/Example-Projects/video-analyzer/.venv/lib/python3.11/site-packages/video_analyzer/cli.py", line 114, in main
    audio_processor = AudioProcessor(model_size=config.get("audio", {}).get("whisper_model", "medium"))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kylehowells/Developer/Example-Projects/video-analyzer/.venv/lib/python3.11/site-packages/video_analyzer/audio_processor.py", line 23, in __init__
    from faster_whisper import WhisperModel
ModuleNotFoundError: No module named 'faster_whisper'
```

So have added `faster_whisper` to requirements file.