### PR TITLE
Work with any OpenAI API compatible LLM service

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -56,7 +56,7 @@ class LLMClient:
 
 2. Generic OpenAI API (generic_openai_api.py)
    - Compatible with OpenAI-style APIs (OpenAI, OpenRouter, etc.)
-   - Configurable service URL (e.g. OpenRouter: https://openrouter.ai/api/v1, OpenAI: https://api.openai.com/v1)
+   - Configurable API URL (e.g. OpenRouter: https://openrouter.ai/api/v1, OpenAI: https://api.openai.com/v1)
    - Sends images as content array with type "image_url"
    - Requires API key and service URL
    - Returns standardized response format
@@ -79,7 +79,7 @@ Key configuration groups:
         },
         "openai_api": {
             "api_key": "",
-            "service_url": "https://openrouter.ai/api/v1",
+            "api_url": "https://openrouter.ai/api/v1",
             "model": "meta-llama/llama-3.2-11b-vision-instruct:free"
         }
     },

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -54,10 +54,11 @@ class LLMClient:
    - Sends images as base64 in "images" array
    - Returns raw response from Ollama
 
-2. OpenRouter (openrouter.py)
-   - Uses OpenRouter's chat completions API
+2. Generic OpenAI API (generic_openai_api.py)
+   - Compatible with OpenAI-style APIs (OpenAI, OpenRouter, etc.)
+   - Configurable service URL (e.g. OpenRouter: https://openrouter.ai/api/v1, OpenAI: https://api.openai.com/v1)
    - Sends images as content array with type "image_url"
-   - Requires specific headers and API key
+   - Requires API key and service URL
    - Returns standardized response format
 
 ## Configuration System
@@ -76,8 +77,9 @@ Key configuration groups:
             "url": "http://localhost:11434",
             "model": "llama3.2-vision"
         },
-        "openrouter": {
+        "openai_api": {
             "api_key": "",
+            "service_url": "https://openrouter.ai/api/v1",
             "model": "meta-llama/llama-3.2-11b-vision-instruct:free"
         }
     },

--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,7 @@ If you want to use OpenAI-compatible APIs (like OpenRouter or OpenAI) instead of
    video-analyzer video.mp4 --client openai_api --api-key your-key --api-url https://openrouter.ai/api/v1
 
    # For OpenAI
-   video-analyzer video.mp4 --client openai_api --api-key your-key --api-url httpd
+   video-analyzer video.mp4 --client openai_api --api-key your-key --api-url https://api.openai.com/v1
    ```
 
    Or add to config/config.json:

--- a/readme.md
+++ b/readme.md
@@ -104,10 +104,10 @@ If you want to use OpenAI-compatible APIs (like OpenRouter or OpenAI) instead of
 2. Configure via command line:
    ```bash
    # For OpenRouter
-   video-analyzer video.mp4 --client openai_api --api-key your-key --service-url https://openrouter.ai/api/v1
+   video-analyzer video.mp4 --client openai_api --api-key your-key --api-url https://openrouter.ai/api/v1
 
    # For OpenAI
-   video-analyzer video.mp4 --client openai_api --api-key your-key --service-url https://api.openai.com/v1
+   video-analyzer video.mp4 --client openai_api --api-key your-key --api-url httpd
    ```
 
    Or add to config/config.json:
@@ -117,7 +117,7 @@ If you want to use OpenAI-compatible APIs (like OpenRouter or OpenAI) instead of
        "default": "openai_api",
        "openai_api": {
          "api_key": "your-api-key",
-         "service_url": "https://openrouter.ai/api/v1"  # or https://api.openai.com/v1
+         "api_url": "https://openrouter.ai/api/v1"  # or https://api.openai.com/v1
        }
      }
    }
@@ -151,7 +151,7 @@ video-analyzer path/to/video.mp4
 
 Using OpenAI-compatible API:
 ```bash
-video-analyzer path/to/video.mp4 --client openai_api --api-key your-key --service-url https://openrouter.ai/api/v1
+video-analyzer path/to/video.mp4 --client openai_api --api-key your-key --api-url https://openrouter.ai/api/v1
 ```
 
 #### Sample Output
@@ -167,7 +167,7 @@ video-analyzer path/to/video.mp4 \
     --output ./custom_output \
     --client openai_api \
     --api-key your-key \
-    --service-url https://openrouter.ai/api/v1 \
+    --api-url https://openrouter.ai/api/v1 \
     --model llama3.2-vision \
     --frames-per-minute 15 \
     --duration 60 \
@@ -185,7 +185,7 @@ video-analyzer path/to/video.mp4 \
 | `--client` | Client to use (ollama or openai_api) | ollama |
 | `--ollama-url` | URL for the Ollama service | http://localhost:11434 |
 | `--api-key` | API key for OpenAI-compatible service | None |
-| `--service-url` | Service URL for OpenAI-compatible API | None |
+| `--api-url` | API URL for OpenAI-compatible API | None |
 | `--model` | Name of the vision model to use | llama3.2-vision |
 | `--frames-per-minute` | Target number of frames to extract | 10 |
 | `--duration` | Duration in seconds to process | None (full video) |
@@ -207,7 +207,7 @@ The tool uses a cascading configuration system:
 - `clients.ollama.url`: URL for the Ollama service
 - `clients.ollama.model`: Vision model to use with Ollama
 - `clients.openai_api.api_key`: API key for OpenAI-compatible service
-- `clients.openai_api.service_url`: Service URL for OpenAI-compatible API
+- `clients.openai_api.api_url`: API URL for OpenAI-compatible API
 - `clients.openai_api.model`: Vision model to use with OpenAI-compatible API
 - `prompt_dir`: Directory containing prompt files
 - `output_dir`: Directory for output files

--- a/readme.md
+++ b/readme.md
@@ -93,26 +93,37 @@ ollama pull llama3.2-vision
 ollama serve
 ```
 
-### OpenRouter Setup (Optional)
+### OpenAI-compatible API Setup (Optional)
 
-If you want to use OpenRouter instead of Ollama:
+If you want to use OpenAI-compatible APIs (like OpenRouter or OpenAI) instead of Ollama:
 
-*Currently you can use llama 3.2 11b vision for free by adding :free to the model in default_config
+1. Get an API key from your provider:
+   - [OpenRouter](https://openrouter.ai)
+   - [OpenAI](https://platform.openai.com)
 
-1. Get an API key from [OpenRouter](https://openrouter.ai)
-2. Either:
-   - Pass it via command line: `--openrouter-key your-api-key`
-   - Or add it to config/config.json:
-     ```json
-     {
-       "clients": {
-         "default": "openrouter",
-         "openrouter": {
-           "api_key": "your-api-key"
-         }
+2. Configure via command line:
+   ```bash
+   # For OpenRouter
+   video-analyzer video.mp4 --client openai_api --api-key your-key --service-url https://openrouter.ai/api/v1
+
+   # For OpenAI
+   video-analyzer video.mp4 --client openai_api --api-key your-key --service-url https://api.openai.com/v1
+   ```
+
+   Or add to config/config.json:
+   ```json
+   {
+     "clients": {
+       "default": "openai_api",
+       "openai_api": {
+         "api_key": "your-api-key",
+         "service_url": "https://openrouter.ai/api/v1"  # or https://api.openai.com/v1
        }
      }
-     ```
+   }
+   ```
+
+Note: With OpenRouter, you can use llama 3.2 11b vision for free by adding :free to the model name
 
 ## Project Structure
 
@@ -138,9 +149,9 @@ Using Ollama (default):
 video-analyzer path/to/video.mp4
 ```
 
-Using OpenRouter:
+Using OpenAI-compatible API:
 ```bash
-video-analyzer path/to/video.mp4 --openrouter-key your-api-key
+video-analyzer path/to/video.mp4 --client openai_api --api-key your-key --service-url https://openrouter.ai/api/v1
 ```
 
 #### Sample Output
@@ -154,8 +165,9 @@ Video Summary**\n\nDuration: 5 minutes and 67 seconds\n\nThe video begins with a
 video-analyzer path/to/video.mp4 \
     --config custom_config.json \
     --output ./custom_output \
-    --client openrouter \
-    --openrouter-key your-api-key \
+    --client openai_api \
+    --api-key your-key \
+    --service-url https://openrouter.ai/api/v1 \
     --model llama3.2-vision \
     --frames-per-minute 15 \
     --duration 60 \
@@ -170,9 +182,10 @@ video-analyzer path/to/video.mp4 \
 | `video_path` | Path to the input video file | (Required) |
 | `--config` | Path to configuration directory | config/ |
 | `--output` | Output directory for analysis results | output/ |
-| `--client` | Client to use (ollama or openrouter) | ollama |
+| `--client` | Client to use (ollama or openai_api) | ollama |
 | `--ollama-url` | URL for the Ollama service | http://localhost:11434 |
-| `--openrouter-key` | API key for OpenRouter service | None |
+| `--api-key` | API key for OpenAI-compatible service | None |
+| `--service-url` | Service URL for OpenAI-compatible API | None |
 | `--model` | Name of the vision model to use | llama3.2-vision |
 | `--frames-per-minute` | Target number of frames to extract | 10 |
 | `--duration` | Duration in seconds to process | None (full video) |
@@ -190,11 +203,12 @@ The tool uses a cascading configuration system:
 ### Configuration Options
 
 #### General Settings
-- `clients.default`: Default client to use (ollama or openrouter)
+- `clients.default`: Default client to use (ollama or openai_api)
 - `clients.ollama.url`: URL for the Ollama service
 - `clients.ollama.model`: Vision model to use with Ollama
-- `clients.openrouter.api_key`: API key for OpenRouter service
-- `clients.openrouter.model`: Vision model to use with OpenRouter
+- `clients.openai_api.api_key`: API key for OpenAI-compatible service
+- `clients.openai_api.service_url`: Service URL for OpenAI-compatible API
+- `clients.openai_api.model`: Vision model to use with OpenAI-compatible API
 - `prompt_dir`: Directory containing prompt files
 - `output_dir`: Directory for output files
 - `frames.per_minute`: Target number of frames to extract per minute

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
-# Video Analysis using Llama3.2 Vision and OpenAI's Whisper Models locally
+# Video Analysis using vision models like Llama3.2 Vision and OpenAI's Whisper Models
 
-A video analysis tool that combines Llama's 11B vision model and Whisper to create a description by taking key frames, feeding them to the vision model to get details. It uses the details from each frame and the transcript, if available, to describe what's happening in the video. 
+A video analysis tool that combines vision models like Llama's 11B vision model and Whisper to create a description by taking key frames, feeding them to the vision model to get details. It uses the details from each frame and the transcript, if available, to describe what's happening in the video. 
 
 ## Features
 - 💻 Can run completely locally - no cloud services or API keys needed
-- ☁️  Or, Leverage openrouter's LLM service for speed and scale
+- ☁️  Or, leverage any OpenAI API compatible LLM service (openrouter, openai, etc) for speed and scale
 - 🎬 Intelligent key frame extraction from videos
 - 🔊 High-quality audio transcription using OpenAI's Whisper
 - 👁️ Frame analysis using Ollama and Llama3.2 11B Vision Model

--- a/video_analyzer/cli.py
+++ b/video_analyzer/cli.py
@@ -14,7 +14,7 @@ from .prompt import PromptLoader
 from .analyzer import VideoAnalyzer
 from .audio_processor import AudioProcessor, AudioTranscript
 from .clients.ollama import OllamaClient
-from .clients.openrouter import OpenRouterClient
+from .clients.generic_openai_api import GenericOpenAIAPIClient
 
 # Initialize logger at module level
 logger = logging.getLogger(__name__)
@@ -51,9 +51,9 @@ def create_client(config: Config):
     client_config = get_client(config)
     
     if client_type == "ollama":
-        return OllamaClient(client_config)
-    elif client_type == "openrouter":
-        return OpenRouterClient(client_config)
+        return OllamaClient(client_config["url"])
+    elif client_type == "openai_api":
+        return GenericOpenAIAPIClient(client_config["api_key"], client_config["service_url"])
     else:
         raise ValueError(f"Unknown client type: {client_type}")
 
@@ -65,7 +65,8 @@ def main():
     parser.add_argument("--output", type=str, help="Output directory for analysis results")
     parser.add_argument("--client", type=str, help="Client to use (ollama or openrouter)")
     parser.add_argument("--ollama-url", type=str, help="URL for the Ollama service")
-    parser.add_argument("--openrouter-key", type=str, help="API key for OpenRouter service")
+    parser.add_argument("--api-key", type=str, help="API key for OpenAI-compatible service")
+    parser.add_argument("--service-url", type=str, help="Service URL for OpenAI-compatible API")
     parser.add_argument("--model", type=str, help="Name of the vision model to use")
     parser.add_argument("--duration", type=float, help="Duration in seconds to process")
     parser.add_argument("--keep-frames", action="store_true", help="Keep extracted frames after analysis")

--- a/video_analyzer/cli.py
+++ b/video_analyzer/cli.py
@@ -53,7 +53,7 @@ def create_client(config: Config):
     if client_type == "ollama":
         return OllamaClient(client_config["url"])
     elif client_type == "openai_api":
-        return GenericOpenAIAPIClient(client_config["api_key"], client_config["service_url"])
+        return GenericOpenAIAPIClient(client_config["api_key"], client_config["api_url"])
     else:
         raise ValueError(f"Unknown client type: {client_type}")
 
@@ -66,7 +66,7 @@ def main():
     parser.add_argument("--client", type=str, help="Client to use (ollama or openrouter)")
     parser.add_argument("--ollama-url", type=str, help="URL for the Ollama service")
     parser.add_argument("--api-key", type=str, help="API key for OpenAI-compatible service")
-    parser.add_argument("--service-url", type=str, help="Service URL for OpenAI-compatible API")
+    parser.add_argument("--api-url", type=str, help="API URL for OpenAI-compatible API")
     parser.add_argument("--model", type=str, help="Name of the vision model to use")
     parser.add_argument("--duration", type=float, help="Duration in seconds to process")
     parser.add_argument("--keep-frames", action="store_true", help="Keep extracted frames after analysis")

--- a/video_analyzer/clients/generic_openai_api.py
+++ b/video_analyzer/clients/generic_openai_api.py
@@ -10,13 +10,13 @@ logger = logging.getLogger(__name__)
 
 # Constants
 DEFAULT_MAX_RETRIES = 3
-RATE_LIMIT_WAIT_TIME = 25 # seconds
+RATE_LIMIT_WAIT_TIME = 25  # seconds
 DEFAULT_WAIT_TIME = 25  # seconds
 
-class OpenRouterClient(LLMClient):
-    def __init__(self, api_key: str, max_retries: int = DEFAULT_MAX_RETRIES):
+class GenericOpenAIAPIClient(LLMClient):
+    def __init__(self, api_key: str, service_url: str, max_retries: int = DEFAULT_MAX_RETRIES):
         self.api_key = api_key
-        self.base_url = "https://openrouter.ai/api/v1"
+        self.base_url = service_url.rstrip('/')  # Remove trailing slash if present
         self.generate_url = f"{self.base_url}/chat/completions"
         self.max_retries = max_retries
 
@@ -27,7 +27,7 @@ class OpenRouterClient(LLMClient):
         model: str = "llama3.2-vision",
         temperature: float = 0.2,
         num_predict: int = 256) -> Dict[Any, Any]:
-        """Generate response from OpenRouter API."""
+        """Generate response from OpenAI-compatible API."""
         # Prepare request content
         if image_path:
             base64_image = self.encode_image(image_path)

--- a/video_analyzer/clients/generic_openai_api.py
+++ b/video_analyzer/clients/generic_openai_api.py
@@ -14,9 +14,9 @@ RATE_LIMIT_WAIT_TIME = 25  # seconds
 DEFAULT_WAIT_TIME = 25  # seconds
 
 class GenericOpenAIAPIClient(LLMClient):
-    def __init__(self, api_key: str, service_url: str, max_retries: int = DEFAULT_MAX_RETRIES):
+    def __init__(self, api_key: str, api_url: str, max_retries: int = DEFAULT_MAX_RETRIES):
         self.api_key = api_key
-        self.base_url = service_url.rstrip('/')  # Remove trailing slash if present
+        self.base_url = api_url.rstrip('/')  # Remove trailing slash if present
         self.generate_url = f"{self.base_url}/chat/completions"
         self.max_retries = max_retries
 

--- a/video_analyzer/config.py
+++ b/video_analyzer/config.py
@@ -69,8 +69,8 @@ class Config:
                     # If key is provided but no client specified, use OpenAI API
                     if not args.client:
                         self.config["clients"]["default"] = "openai_api"
-                elif key == "service_url":
-                    self.config["clients"]["openai_api"]["service_url"] = value
+                elif key == "api_url":
+                    self.config["clients"]["openai_api"]["api_url"] = value
                 elif key == "model":
                     client = self.config["clients"]["default"]
                     self.config["clients"][client]["model"] = value
@@ -99,14 +99,14 @@ def get_client(config: Config) -> dict:
         return {"url": client_config.get("url", "http://localhost:11434")}
     elif client_type == "openai_api":
         api_key = client_config.get("api_key")
-        service_url = client_config.get("service_url")
+        api_url = client_config.get("api_url")
         if not api_key:
             raise ValueError("API key is required when using OpenAI API client")
-        if not service_url:
-            raise ValueError("Service URL is required when using OpenAI API client")
+        if not api_url:
+            raise ValueError("API URL is required when using OpenAI API client")
         return {
             "api_key": api_key,
-            "service_url": service_url
+            "api_url": api_url
         }
     else:
         raise ValueError(f"Unknown client type: {client_type}")

--- a/video_analyzer/config.py
+++ b/video_analyzer/config.py
@@ -64,11 +64,13 @@ class Config:
                     self.config["clients"]["default"] = value
                 elif key == "ollama_url":
                     self.config["clients"]["ollama"]["url"] = value
-                elif key == "openrouter_key":
-                    self.config["clients"]["openrouter"]["api_key"] = value
-                    # If key is provided but no client specified, use OpenRouter
+                elif key == "api_key":
+                    self.config["clients"]["openai_api"]["api_key"] = value
+                    # If key is provided but no client specified, use OpenAI API
                     if not args.client:
-                        self.config["clients"]["default"] = "openrouter"
+                        self.config["clients"]["default"] = "openai_api"
+                elif key == "service_url":
+                    self.config["clients"]["openai_api"]["service_url"] = value
                 elif key == "model":
                     client = self.config["clients"]["default"]
                     self.config["clients"][client]["model"] = value
@@ -88,18 +90,24 @@ class Config:
             logger.error(f"Error saving user config: {e}")
             raise
 
-def get_client(config: Config) -> str:
-    """Get the appropriate client based on configuration."""
+def get_client(config: Config) -> dict:
+    """Get the appropriate client configuration based on configuration."""
     client_type = config.get("clients", {}).get("default", "ollama")
     client_config = config.get("clients", {}).get(client_type, {})
     
     if client_type == "ollama":
-        return client_config.get("url", "http://localhost:11434")
-    elif client_type == "openrouter":
+        return {"url": client_config.get("url", "http://localhost:11434")}
+    elif client_type == "openai_api":
         api_key = client_config.get("api_key")
+        service_url = client_config.get("service_url")
         if not api_key:
-            raise ValueError("OpenRouter API key is required when using OpenRouter client")
-        return api_key
+            raise ValueError("API key is required when using OpenAI API client")
+        if not service_url:
+            raise ValueError("Service URL is required when using OpenAI API client")
+        return {
+            "api_key": api_key,
+            "service_url": service_url
+        }
     else:
         raise ValueError(f"Unknown client type: {client_type}")
 

--- a/video_analyzer/config/default_config.json
+++ b/video_analyzer/config/default_config.json
@@ -8,7 +8,7 @@
         "openai_api": {
             "api_key": "",
             "model": "meta-llama/llama-3.2-11b-vision-instruct",
-            "service_url": "https://openrouter.ai/api/v1"
+            "api_url": "https://openrouter.ai/api/v1"
         }
     },
     "prompt_dir": "prompts",

--- a/video_analyzer/config/default_config.json
+++ b/video_analyzer/config/default_config.json
@@ -5,9 +5,10 @@
             "url": "http://localhost:11434",
             "model": "llama3.2-vision"
         },
-        "openrouter": {
+        "openai_api": {
             "api_key": "",
-            "model": "meta-llama/llama-3.2-11b-vision-instruct"
+            "model": "meta-llama/llama-3.2-11b-vision-instruct",
+            "service_url": "https://openrouter.ai/api/v1"
         }
     },
     "prompt_dir": "prompts",


### PR DESCRIPTION
config and param changed from openrouter to openai to make it generic and usable for any service that uses the OpenAI API spec

Just specify the api url on the command line 

parameter and config changed from `openrouter-key` to `api-key`

Examples

```bash
   # For OpenRouter
   video-analyzer video.mp4 --client openai_api --api-key your-key --api-url https://openrouter.ai/api/v1 --model meta-llama/llama-3.2-11b-vision-instruct

   # For OpenAI
   video-analyzer video.mp4 --client openai_api --api-key your-key --api-url https://api.openai.com/v1 --model gpt-4o-mini
```

