### PR TITLE
fix issue where installing via . as opposed to -e . can't find prompt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,8 @@
 include requirements.txt
 include readme.md
 include LICENSE
-recursive-include config *
-recursive-include prompts *
+recursive-include video_analyzer/config *
+recursive-include video_analyzer/prompts *
 global-exclude __pycache__
 global-exclude *.py[cod]
 global-exclude *.so

--- a/setup.py
+++ b/setup.py
@@ -8,22 +8,6 @@ with open("readme.md", "r", encoding="utf-8") as fh:
 with open("requirements.txt", "r", encoding="utf-8") as fh:
     requirements = [line.strip() for line in fh if line.strip() and not line.startswith("#")]
 
-# Create data_files list for config and prompts
-data_files = [
-    ('video_analyzer/config', ['video_analyzer/config/default_config.json'])
-]
-
-# Recursively add all files from prompts directory
-prompts_dir = Path('prompts')
-for path in prompts_dir.rglob('*'):
-    if path.is_file():
-        # Convert path to relative path from prompts directory
-        relative_path = path.relative_to(prompts_dir)
-        # Create the target directory path
-        target_dir = f'video_analyzer/prompts/{relative_path.parent}'
-        # Add the file to data_files
-        data_files.append((target_dir, [str(path)]))
-
 setup(
     name="video-analyzer",
     version="0.1.0",
@@ -32,6 +16,12 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),
+    package_data={
+        'video_analyzer': [
+            'config/*.json',
+            'prompts/**/*',
+        ],
+    },
     install_requires=requirements,
     entry_points={
         "console_scripts": [
@@ -39,6 +29,5 @@ setup(
         ],
     },
     python_requires=">=3.8",
-    include_package_data=True,
-    data_files=data_files
+    include_package_data=True
 )


### PR DESCRIPTION
install wasn't do the right thing and the right files (prompts and config) weren't being moved to the package location. 

Things always worked when installing via `pip install -e .` because it was pointing at the source files. 

Honestly they should probably be put in some system library directory but this will unblock users for now. 

uninstall `pip uninstall video-analyzer` install again from source using `pip install .` if you've already removed the source code or don't know where it is just start the install from scratch.