### PR TITLE
--max-frames now sample frame evenly across a video

### DIFF
--- a/docs/USAGES.md
+++ b/docs/USAGES.md
@@ -37,7 +37,7 @@ video-analyzer path/to/video.mp4 --client openai_api --api-key your-key --api-ur
 | `--keep-frames` | Keep extracted frames after analysis | False | `--keep-frames` |
 | `--whisper-model` | Whisper model size or model path | medium | `--whisper-model large` |
 | `--start-stage` | Stage to start processing from (1-3) | 1 | `--start-stage 2` |
-| `--max-frames` | Maximum number of frames to process | sys.maxsize | `--max-frames 100` |
+| `--max-frames` | Maximum number of frames to process. When specified, frames are sampled evenly across the video duration rather than just taking the first N frames. | sys.maxsize | `--max-frames 100` |
 | `--log-level` | Set logging level | INFO | `--log-level DEBUG` |
 | `--prompt` | Question to ask about the video | "" | `--prompt "What activities are shown?"` |
 | `--language` | Set language for transcription | None (auto-detect) | `--language en` |
@@ -158,6 +158,14 @@ video-analyzer video.mp4 \
     --max-frames 50 \
     --keep-frames
 ```
+
+### Analyze Video with Evenly Sampled Frames
+```bash
+video-analyzer video.mp4 \
+    --max-frames 5 \
+    --keep-frames
+```
+This will extract frames evenly spaced across the video duration. For example, in a 5-minute video, it would sample approximately one frame per minute rather than taking the first 5 frames.
 
 ### Specific Language Processing
 ```bash

--- a/video_analyzer/cli.py
+++ b/video_analyzer/cli.py
@@ -141,10 +141,9 @@ def main():
             )
             frames = processor.extract_keyframes(
                 frames_per_minute=config.get("frames", {}).get("per_minute", 60),
-                duration=config.get("duration")
+                duration=config.get("duration"),
+                max_frames=args.max_frames
             )
-            # Limit frames if max_frames specified
-            frames = frames[:args.max_frames]
             
         # Stage 2: Frame Analysis
         if args.start_stage <= 2:


### PR DESCRIPTION
When max_frames (x) is specified and there are more candidate frames than x, the code now: Calculates a step size = total_candidates / x
Selects x frames at evenly spaced intervals using this step size This ensures the frames represent the entire video duration rather than just the beginning For example, if there are 100 candidate frames and max_frames=5, it will select frames at indices 0, 20, 40, 60, and 80, giving an even sampling across the video.