### PR TITLE
Corrected the model in OpenAI command and changed gpt-4o-mini to gpt-4o

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,10 +124,10 @@ If you want to use OpenAI-compatible APIs (like OpenRouter or OpenAI) instead of
 2. Configure via command line:
    ```bash
    # For OpenRouter
-   video-analyzer video.mp4 --client openai_api --api-key your-key --api-url https://openrouter.ai/api/v1 --model gpt-4o-mini
+   video-analyzer video.mp4 --client openai_api --api-key your-key --api-url https://openrouter.ai/api/v1 --model gpt-4o
 
    # For OpenAI
-   video-analyzer video.mp4 --client openai_api --api-key your-key --api-url https://api.openai.com/v1 --model meta-llama/llama-3.2-11b-vision-instruct
+   video-analyzer video.mp4 --client openai_api --api-key your-key --api-url https://api.openai.com/v1 --model gpt-4o
    ```
 
    Or add to config/config.json:


### PR DESCRIPTION
I've corrected the model in the OpenAI command and changed gpt-4o-mini to gpt-4o because of the weird pricing of gpt-4o-mini.