### PR TITLE
Add error handling for audio extraction in main function

### DIFF
--- a/video_analyzer/cli.py
+++ b/video_analyzer/cli.py
@@ -123,7 +123,11 @@ def main():
                                              device=config.get("audio", {}).get("device", "cpu"))
             
             logger.info("Extracting audio from video...")
-            audio_path = audio_processor.extract_audio(video_path, output_dir)
+            try:
+                audio_path = audio_processor.extract_audio(video_path, output_dir)
+            except Exception as e:
+                logger.error(f"Error extracting audio: {e}")
+                audio_path = None
             
             if audio_path is None:
                 logger.debug("No audio found in video - skipping transcription")


### PR DESCRIPTION
avoid IndexError when video without audio
```
Traceback (most recent call last):
  File "/workspace/repo/video-analyzer/.venv/lib/python3.10/site-packages/video_analyzer/audio_processor.py", line 67, in extract_audio
    subprocess.run([
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['ffmpeg', '-i', 'video0.mp4', '-vn', '-acodec', 'pcm_s16le', '-ar', '16000', '-ac', '1', '-y', 'output/audio.wav']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/workspace/repo/video-analyzer/.venv/lib/python3.10/site-packages/video_analyzer/audio_processor.py", line 91, in extract_audio
    video = AudioSegment.from_file(str(video_path))
  File "/workspace/repo/video-analyzer/.venv/lib/python3.10/site-packages/pydub/audio_segment.py", line 734, in from_file
    audio_codec = audio_streams[0].get('codec_name')
IndexError: list index out of range
```

