### PR TITLE
Add audioop-lts for Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ openai-whisper>=20231117
 requests>=2.31.0
 Pillow>=10.0.0
 pydub>=0.25.1
+audioop-lts>=0.2.2; python_version >= "3.13"
 faster-whisper>=0.6.0


### PR DESCRIPTION
## Summary
- add `audioop-lts` as a conditional dependency for Python 3.13+
- keep `pydub` working on Python versions where `audioop` was removed from the standard library

## Context
Python 3.13 removed the stdlib `audioop` module:
- https://peps.python.org/pep-0594/#id4

`pydub` still imports `audioop` at import time, which breaks the CLI during startup unless a compatible replacement is installed. Relevant discussion:
- https://github.com/jiaaro/pydub/issues/815#issuecomment-2442411085

This change adds:
- `audioop-lts>=0.2.2; python_version >= "3.13"`

That keeps fresh installs working on Python 3.13 without changing the application's runtime behavior.

## Testing
- installed the package in a Python 3.13 virtualenv
- verified `audioop` resolves from `audioop-lts`
- verified `video-analyzer --help` starts successfully