### PR TITLE
Add mlx-whisper audio backend

### DIFF
--- a/docs/USAGES.md
+++ b/docs/USAGES.md
@@ -88,6 +88,7 @@ The tool uses a cascading configuration system with the following priority:
     "narrative": 1024
   },
   "audio": {
+    "backend": "faster-whisper",
     "sample_rate": 16000,
     "channels": 1,
     "quality_threshold": 0.5,
@@ -123,12 +124,18 @@ The tool uses a cascading configuration system with the following priority:
 - `response_length.narrative`: Max length for enhanced narrative
 
 #### Audio Processing Settings
+- `audio.backend`: Whisper backend to use (`faster-whisper` or `mlx-whisper`)
 - `audio.sample_rate`: Audio sample rate in Hz
 - `audio.channels`: Number of audio channels
 - `audio.quality_threshold`: Minimum quality for transcription
 - `audio.chunk_length`: Audio chunk processing length
 - `audio.language_confidence_threshold`: Language detection confidence
 - `audio.language`: Force specific language (null for auto-detect)
+
+### Current Behavior Notes
+
+- `audio.backend` defaults to `faster-whisper`.
+- `mlx-whisper` is intended for Apple Silicon environments and may require installing optional MLX dependencies with `pip install \".[mlx]\"`.
 
 #### General Settings
 - `prompt_dir`: Custom prompt directory path

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,8 @@ source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 pip install .  # For regular installation
 # OR
 pip install -e .  # For development installation
+# OR
+pip install ".[mlx]"  # For optional mlx-whisper backend support on Apple Silicon
 ```
 
 4. Install FFmpeg:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests>=2.31.0
 Pillow>=10.0.0
 pydub>=0.25.1
 faster-whisper>=0.6.0
+mlx-whisper>=0.4.1; platform_system == "Darwin" and platform_machine == "arm64"

--- a/tests/test_whisper_backends.py
+++ b/tests/test_whisper_backends.py
@@ -1,0 +1,35 @@
+import sys
+import types
+
+import pytest
+
+from video_analyzer.whisper_backends import MlxWhisperBackend, create_whisper_backend
+
+
+def test_create_whisper_backend_rejects_unknown_backend():
+    with pytest.raises(ValueError, match="Unknown whisper backend"):
+        create_whisper_backend("unknown", "medium", "cpu")
+
+
+def test_mlx_whisper_backend_forwards_expected_transcribe_options(monkeypatch):
+    captured = {}
+
+    def fake_transcribe(audio_path, **kwargs):
+        captured["audio_path"] = audio_path
+        captured.update(kwargs)
+        return {"text": "hello", "segments": [{"text": "hello"}], "language": "en"}
+
+    fake_module = types.SimpleNamespace(transcribe=fake_transcribe)
+    monkeypatch.setitem(sys.modules, "mlx_whisper", fake_module)
+
+    backend = MlxWhisperBackend("mlx-community/whisper-large-v3-turbo-asr-fp16")
+    result = backend.transcribe("audio.wav", language="en")
+
+    assert result["text"] == "hello"
+    assert captured == {
+        "audio_path": "audio.wav",
+        "path_or_hf_repo": "mlx-community/whisper-large-v3-turbo-asr-fp16",
+        "word_timestamps": True,
+        "temperature": 0,
+        "language": "en",
+    }

--- a/video_analyzer/audio_processor.py
+++ b/video_analyzer/audio_processor.py
@@ -6,9 +6,14 @@ import subprocess
 import torch
 from pydub import AudioSegment
 
+from .whisper_backends import WhisperBackend
+
 # Set up logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
+
 
 @dataclass
 class AudioTranscript:
@@ -16,42 +21,28 @@ class AudioTranscript:
     segments: List[Dict[str, Any]]
     language: str
 
-class AudioProcessor:
-    def __init__(self, 
-                 language: str | None = None,
-                 model_size_or_path: str = "medium",
-                 device: str = "cpu"):
-        """Initialize audio processor with specified Whisper model size or model path. By default, the medium model is used."""
-        try:
-            from faster_whisper import WhisperModel
-            
-            # Log cache directory
-            cache_dir = Path.home() / ".cache" / "huggingface" / "hub"
-            logger.debug(f"Using HuggingFace cache directory: {cache_dir}")
-            
-            # Force CPU usage for now faster whisper having issues with cudas
-            self.device = device
-            compute_type = "float32"
-            logger.debug(f"Using device: {self.device}")
 
+class AudioProcessor:
+    def __init__(
+        self,
+        backend: WhisperBackend,
+        language: str | None = None,
+    ):
+        """Initialize audio processor with a configured Whisper backend."""
+        try:
+            self.backend = backend
             self.language = language if language else None
 
-            self.model = WhisperModel(
-                model_size_or_path,
-                device=device,
-                compute_type=compute_type
-            )
-            logger.info(f"Initiation Input: Model size or path: {model_size_or_path}, Device: {device}, Compute type: {compute_type}, Language: {self.language if self.language else 'auto detected'}")
-            logger.debug(f"Successfully loaded Whisper model: {model_size_or_path}")
-            
             # Check for ffmpeg installation
             try:
-                subprocess.run(['ffmpeg', '-version'], capture_output=True, check=True)
+                subprocess.run(["ffmpeg", "-version"], capture_output=True, check=True)
                 self.has_ffmpeg = True
             except (subprocess.CalledProcessError, FileNotFoundError):
                 self.has_ffmpeg = False
-                logger.warning("FFmpeg not found. Please install ffmpeg for better audio extraction.")
-                
+                logger.warning(
+                    "FFmpeg not found. Please install ffmpeg for better audio extraction."
+                )
+
         except Exception as e:
             logger.error(f"Error loading Whisper model: {e}")
             raise
@@ -61,30 +52,41 @@ class AudioProcessor:
         Returns None if video has no audio streams."""
         audio_path = output_dir / "audio.wav"
         output_dir.mkdir(parents=True, exist_ok=True)
-        
+
         try:
             # Extract audio using ffmpeg
-            subprocess.run([
-                "ffmpeg", "-i", str(video_path),
-                "-vn",  # No video
-                "-acodec", "pcm_s16le",  # PCM 16-bit little-endian
-                "-ar", "16000",  # 16kHz sampling rate
-                "-ac", "1",  # Mono
-                "-y",  # Overwrite output
-                str(audio_path)
-            ], check=True, capture_output=True)
-            
+            subprocess.run(
+                [
+                    "ffmpeg",
+                    "-i",
+                    str(video_path),
+                    "-vn",  # No video
+                    "-acodec",
+                    "pcm_s16le",  # PCM 16-bit little-endian
+                    "-ar",
+                    "16000",  # 16kHz sampling rate
+                    "-ac",
+                    "1",  # Mono
+                    "-y",  # Overwrite output
+                    str(audio_path),
+                ],
+                check=True,
+                capture_output=True,
+            )
+
             logger.debug("Successfully extracted audio using ffmpeg")
             return audio_path
         except subprocess.CalledProcessError as e:
             error_output = e.stderr.decode()
             logger.error(f"FFmpeg error: {error_output}")
-            
+
             # Check if error indicates no audio streams
             if "Output file does not contain any stream" in error_output:
-                logger.debug("No audio streams found in video - skipping audio extraction")
+                logger.debug(
+                    "No audio streams found in video - skipping audio extraction"
+                )
                 return None
-                
+
             # If error is not about missing audio, try pydub as fallback
             logger.info("Falling back to pydub for audio extraction...")
             try:
@@ -106,51 +108,153 @@ class AudioProcessor:
     def transcribe(self, audio_path: Path) -> Optional[AudioTranscript]:
         """Transcribe audio file using Whisper with quality checks."""
         accepted_languages = {
-                "af", "am", "ar", "as", "az", "ba", "be", "bg", "bn", "bo", "br", "bs", "ca", "cs", "cy", "da", "de", "el", "en", "es", "et", "eu", "fa", "fi", "fo", "fr", "gl", "gu", "ha", "haw", "he", "hi", "hr", "ht", "hu", "hy", "id", "is", "it", "ja", "jw", "ka", "kk", "km", "kn", "ko", "la", "lb", "ln", "lo", "lt", "lv", "mg", "mi", "mk", "ml", "mn", "mr", "ms", "mt", "my", "ne", "nl", "nn", "no", "oc", "pa", "pl", "ps", "pt", "ro", "ru", "sa", "sd", "si", "sk", "sl", "sn", "so", "sq", "sr", "su", "sv", "sw", "ta", "te", "tg", "th", "tk", "tl", "tr", "tt", "uk", "ur", "uz", "vi", "yi", "yo", "zh", "yue"
+            "af",
+            "am",
+            "ar",
+            "as",
+            "az",
+            "ba",
+            "be",
+            "bg",
+            "bn",
+            "bo",
+            "br",
+            "bs",
+            "ca",
+            "cs",
+            "cy",
+            "da",
+            "de",
+            "el",
+            "en",
+            "es",
+            "et",
+            "eu",
+            "fa",
+            "fi",
+            "fo",
+            "fr",
+            "gl",
+            "gu",
+            "ha",
+            "haw",
+            "he",
+            "hi",
+            "hr",
+            "ht",
+            "hu",
+            "hy",
+            "id",
+            "is",
+            "it",
+            "ja",
+            "jw",
+            "ka",
+            "kk",
+            "km",
+            "kn",
+            "ko",
+            "la",
+            "lb",
+            "ln",
+            "lo",
+            "lt",
+            "lv",
+            "mg",
+            "mi",
+            "mk",
+            "ml",
+            "mn",
+            "mr",
+            "ms",
+            "mt",
+            "my",
+            "ne",
+            "nl",
+            "nn",
+            "no",
+            "oc",
+            "pa",
+            "pl",
+            "ps",
+            "pt",
+            "ro",
+            "ru",
+            "sa",
+            "sd",
+            "si",
+            "sk",
+            "sl",
+            "sn",
+            "so",
+            "sq",
+            "sr",
+            "su",
+            "sv",
+            "sw",
+            "ta",
+            "te",
+            "tg",
+            "th",
+            "tk",
+            "tl",
+            "tr",
+            "tt",
+            "uk",
+            "ur",
+            "uz",
+            "vi",
+            "yi",
+            "yo",
+            "zh",
+            "yue",
         }
         if self.language and self.language not in accepted_languages:
-            logger.warning(f"Invalid language code: {self.language}, will detect language automatically")
-        try:
-            # Initial transcription with VAD filtering
-            segments, info = self.model.transcribe(
-                str(audio_path),
-                beam_size=5,
-                word_timestamps=True,
-                vad_filter=True,
-                vad_parameters=dict(min_silence_duration_ms=500),
-                language = self.language if self.language in accepted_languages else None
+            logger.warning(
+                f"Invalid language code: {self.language}, will detect language automatically"
             )
-            
-            segments_list = list(segments)
+        try:
+            language = self.language if self.language in accepted_languages else None
+            result = self.backend.transcribe(str(audio_path), language=language)
+
+            if isinstance(result, tuple):
+                segments, info = result
+                segments_list = list(segments)
+                transcript = AudioTranscript(
+                    text=" ".join(segment.text for segment in segments_list),
+                    segments=[
+                        {
+                            "text": segment.text,
+                            "start": segment.start,
+                            "end": segment.end,
+                            "words": [
+                                {
+                                    "word": word.word,
+                                    "start": word.start,
+                                    "end": word.end,
+                                    "probability": word.probability,
+                                }
+                                for word in (segment.words or [])
+                            ],
+                        }
+                        for segment in segments_list
+                    ],
+                    language=info.language,
+                )
+            else:
+                segments_list = result.get("segments", [])
+                transcript = AudioTranscript(
+                    text=result.get("text", ""),
+                    segments=segments_list,
+                    language=result.get("language", "unknown"),
+                )
+
             if not segments_list:
                 logger.warning("No speech detected in audio")
                 return None
-            
-            # Convert segments to the expected format
-            segment_data = [
-                {
-                    "text": segment.text,
-                    "start": segment.start,
-                    "end": segment.end,
-                    "words": [
-                        {
-                            "word": word.word,
-                            "start": word.start,
-                            "end": word.end,
-                            "probability": word.probability
-                        }
-                        for word in (segment.words or [])
-                    ]
-                }
-                for segment in segments_list
-            ]
-            
-            return AudioTranscript(
-                text=" ".join(segment.text for segment in segments_list),
-                segments=segment_data,
-                language=info.language
-            )
-            
+
+            return transcript
+
         except Exception as e:
             logger.error(f"Error transcribing audio: {e}")
             logger.exception(e)

--- a/video_analyzer/config.py
+++ b/video_analyzer/config.py
@@ -35,7 +35,7 @@ class Config:
         """
         try:
             if self.user_config.exists():
-                logger.debug(f"Loading user config from {self.user_config}")
+                logger.debug(f"Loading user config from {self.user_config.resolve()}")
                 with open(self.user_config) as f:
                     self.config = json.load(f)
             else:

--- a/video_analyzer/config/default_config.json
+++ b/video_analyzer/config/default_config.json
@@ -38,6 +38,7 @@
         "narrative": 500
     },
     "audio": {
+        "backend": "faster-whisper",
         "whisper_model": "medium",
         "sample_rate": 16000,
         "channels": 1,

--- a/video_analyzer/whisper_backends.py
+++ b/video_analyzer/whisper_backends.py
@@ -1,0 +1,72 @@
+import logging
+from typing import Any, Dict, List, Optional, Protocol
+
+
+logger = logging.getLogger(__name__)
+
+
+class WhisperBackend(Protocol):
+    def transcribe(self, audio_path: str, language: Optional[str] = None): ...
+
+
+class FasterWhisperBackend:
+    def __init__(self, model_size_or_path: str = "medium", device: str = "cpu"):
+        from faster_whisper import WhisperModel
+
+        cache_dir = __import__("pathlib").Path.home() / ".cache" / "huggingface" / "hub"
+        logger.debug(f"Using HuggingFace cache directory: {cache_dir}")
+        logger.debug(f"Using device: {device}")
+
+        self.model = WhisperModel(
+            model_size_or_path,
+            device=device,
+            compute_type="float32",
+        )
+        logger.info(
+            f"Initialized faster-whisper backend with model/path: {model_size_or_path}, device: {device}"
+        )
+
+    def transcribe(self, audio_path: str, language: Optional[str] = None):
+        return self.model.transcribe(
+            audio_path,
+            beam_size=5,
+            word_timestamps=True,
+            vad_filter=True,
+            vad_parameters=dict(min_silence_duration_ms=500),
+            language=language,
+        )
+
+
+class MlxWhisperBackend:
+    def __init__(self, model_size_or_path: str = "mlx-community/whisper-turbo"):
+        import mlx_whisper
+
+        self.mlx_whisper = mlx_whisper
+        self.model_size_or_path = model_size_or_path
+        logger.info(
+            f"Initialized mlx-whisper backend with model/path: {model_size_or_path}"
+        )
+
+    def transcribe(self, audio_path: str, language: Optional[str] = None):
+        result = self.mlx_whisper.transcribe(
+            audio_path,
+            path_or_hf_repo=self.model_size_or_path,
+            word_timestamps=True,
+            temperature=0,
+            language=language,
+        )
+        return result
+
+
+def create_whisper_backend(
+    backend: str,
+    model_size_or_path: str,
+    device: str,
+) -> WhisperBackend:
+    if backend == "faster-whisper":
+        return FasterWhisperBackend(
+            model_size_or_path=model_size_or_path, device=device
+        )
+    if backend == "mlx-whisper":
+        return MlxWhisperBackend(model_size_or_path=model_size_or_path)
+    raise ValueError(f"Unknown whisper backend: {backend}")


### PR DESCRIPTION
## Summary
- add an optional `mlx-whisper` audio transcription backend alongside the existing `faster-whisper` path
- make the audio backend configurable through `audio.backend`
- document the optional MLX installation path and backend setting

## Details
- add `video_analyzer/whisper_backends.py` with:
  - `FasterWhisperBackend`
  - `MlxWhisperBackend`
  - `create_whisper_backend(...)`
- refactor `AudioProcessor` to use an injected backend while keeping shared extraction/transcript orchestration in one place
- add `audio.backend` to the packaged default config with `faster-whisper` as the default
- add optional `mlx-whisper` dependency support:
  - conditional dependency in `requirements.txt`
  - `mlx` extra in `setup.py`
- update docs to mention:
  - `audio.backend`
  - `pip install \".[mlx]\"`

## Behavior Notes
- `faster-whisper` keeps the current behavior, including beam search and VAD filtering
- `mlx-whisper` currently uses:
  - `word_timestamps=True`
  - `temperature=0`
  - optional `language`
- `mlx-whisper` does not use `beam_size` because the current library raises `NotImplementedError` for beam search
- `mlx-whisper` also does not support the same VAD options as `faster-whisper`

## Testing
- `python -m pytest -q tests/test_whisper_backends.py`

## Notes
- A full repository-wide `pytest` run currently fails in the separate `video-analyzer-tune` subproject because `dspy` is not installed in this environment