### PR TITLE
feat: add TwelveLabs Pegasus client for whole-video analysis

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ A video analysis tool that combines vision models like Llama's 11B vision model 
 ## Features
 - 💻 Can run completely locally - no cloud services or API keys needed
 - ☁️  Or, leverage any OpenAI API compatible LLM service (openrouter, openai, etc) for speed and scale
+- 🎥 Or, analyze the entire video in a single call with [TwelveLabs Pegasus](https://twelvelabs.io) — no frame extraction or transcription needed
 - 🎬 Intelligent key frame extraction from videos
 - 🔊 High-quality audio transcription using OpenAI's Whisper
 - 👁️ Frame analysis using Ollama and Llama3.2 11B Vision Model
@@ -146,6 +147,39 @@ If you want to use OpenAI-compatible APIs (like OpenRouter or OpenAI) instead of
 
 Note: With OpenRouter, you can use llama 3.2 11b vision for free by adding :free to the model name
 
+### TwelveLabs Setup (Optional)
+
+[TwelveLabs](https://twelvelabs.io) offers Pegasus, a video understanding model
+that ingests an entire video in a single call and reasons jointly over its
+visuals, motion, and audio. When this client is selected, the frame-extraction,
+Whisper transcription, and reconstruction stages are skipped — Pegasus produces
+the description directly from the video.
+
+1. Install the optional dependency:
+   ```bash
+   pip install twelvelabs
+   ```
+
+2. Get an API key from [twelvelabs.io](https://twelvelabs.io) — there's a generous free tier.
+
+3. Run with the TwelveLabs client (the video may be a local file or a public URL):
+   ```bash
+   video-analyzer video.mp4 --client twelvelabs --api-key your-key
+   ```
+
+   Or add to config/config.json:
+   ```json
+   {
+     "clients": {
+       "default": "twelvelabs",
+       "twelvelabs": {
+         "api_key": "your-api-key",
+         "model": "pegasus1.5"
+       }
+     }
+   }
+   ```
+
 ## Design
 For detailed information about the project's design and implementation, including how to make changes, see [docs/DESIGN.md](docs/DESIGN.md).
 
@@ -165,6 +199,11 @@ video-analyzer video.mp4 \
     --api-key your-key \
     --api-url https://openrouter.ai/api/v1 \
     --model meta-llama/llama-3.2-11b-vision-instruct:free
+
+# Whole-video analysis with TwelveLabs Pegasus
+video-analyzer video.mp4 \
+    --client twelvelabs \
+    --api-key your-key
 
 # Analysis with custom prompt
 video-analyzer video.mp4 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ Pillow>=10.0.0
 pydub>=0.25.1
 audioop-lts>=0.2.2; python_version >= "3.13"
 faster-whisper>=0.6.0
+# Optional: only needed for the TwelveLabs (Pegasus) client (--client twelvelabs)
+twelvelabs>=1.2.8

--- a/test_twelvelabs_client.py
+++ b/test_twelvelabs_client.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Tests for the TwelveLabs (Pegasus) client.
+
+The unit tests run without network access or the SDK installed. The live
+test calls the real Pegasus API and is skipped unless TWELVELABS_API_KEY is set.
+"""
+import os
+
+from video_analyzer.clients.twelvelabs import TwelveLabsClient, MIN_MAX_TOKENS
+
+# A short, publicly hosted sample video that TwelveLabs can fetch server-side.
+SAMPLE_VIDEO_URL = (
+    "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/720/"
+    "Big_Buck_Bunny_720_10s_1MB.mp4"
+)
+
+
+def test_url_detection():
+    """URLs and local paths are classified correctly."""
+    assert TwelveLabsClient._is_url("https://example.com/video.mp4")
+    assert TwelveLabsClient._is_url("http://example.com/video.mp4")
+    assert not TwelveLabsClient._is_url("/tmp/video.mp4")
+    assert not TwelveLabsClient._is_url("video.mp4")
+
+
+def test_empty_api_key_rejected():
+    """An empty API key raises a clear error before any network call."""
+    try:
+        TwelveLabsClient("")
+        assert False, "Expected ValueError for empty API key"
+    except ValueError:
+        pass
+
+
+def test_generate_not_supported():
+    """Per-frame generate() is unsupported; whole-video analyze_video() is used."""
+    key = os.environ.get("TWELVELABS_API_KEY")
+    if not key:
+        print("Skipping test_generate_not_supported (TWELVELABS_API_KEY not set)")
+        return
+    client = TwelveLabsClient(key)
+    try:
+        client.generate(prompt="hi", image_path="frame.jpg")
+        assert False, "Expected NotImplementedError from generate()"
+    except NotImplementedError:
+        pass
+
+
+def test_min_max_tokens_constant():
+    """The Pegasus max_tokens floor is exposed as a constant."""
+    assert MIN_MAX_TOKENS == 512
+
+
+def test_analyze_video_live():
+    """End-to-end Pegasus call against a public sample video (network + key)."""
+    key = os.environ.get("TWELVELABS_API_KEY")
+    if not key:
+        print("Skipping test_analyze_video_live (TWELVELABS_API_KEY not set)")
+        return
+    client = TwelveLabsClient(key)
+    result = client.analyze_video(
+        video=SAMPLE_VIDEO_URL,
+        prompt="Describe this video in one sentence.",
+        max_tokens=512,
+    )
+    assert "response" in result
+    assert isinstance(result["response"], str)
+    assert result["response"].strip(), "Expected a non-empty description"
+    print(f"Live analysis result: {result['response'][:200]}")
+
+
+if __name__ == "__main__":
+    test_url_detection()
+    test_empty_api_key_rejected()
+    test_min_max_tokens_constant()
+    test_generate_not_supported()
+    test_analyze_video_live()
+    print("All tests passed!")

--- a/video_analyzer/cli.py
+++ b/video_analyzer/cli.py
@@ -15,6 +15,7 @@ from .analyzer import VideoAnalyzer
 from .audio_processor import AudioProcessor, AudioTranscript
 from .clients.ollama import OllamaClient
 from .clients.generic_openai_api import GenericOpenAIAPIClient
+from .clients.twelvelabs import TwelveLabsClient
 
 # Initialize logger at module level
 logger = logging.getLogger(__name__)
@@ -54,8 +55,57 @@ def create_client(config: Config):
         return OllamaClient(client_config["url"])
     elif client_type == "openai_api":
         return GenericOpenAIAPIClient(client_config["api_key"], client_config["api_url"])
+    elif client_type == "twelvelabs":
+        return TwelveLabsClient(client_config["api_key"], get_model(config))
     else:
         raise ValueError(f"Unknown client type: {client_type}")
+
+def run_twelvelabs(args, config: Config, client, model: str, output_dir: Path):
+    """Run a single whole-video analysis using TwelveLabs' Pegasus model.
+
+    Pegasus reasons jointly over visuals, motion, and audio, so it replaces
+    the frame-sampling, transcription, and reconstruction stages with one call.
+    Results are written to the same analysis.json shape used by the other
+    clients so downstream tooling continues to work.
+    """
+    user_prompt = config.get("prompt", "") or "Describe what happens in this video in detail."
+    temperature = config.get("clients", {}).get("temperature", 0.2)
+    max_tokens = config.get("response_length", {}).get("reconstruction", 2048)
+
+    logger.info(f"Analyzing video with TwelveLabs model {model}...")
+    video_description = client.analyze_video(
+        video=str(args.video_path),
+        prompt=user_prompt,
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    results = {
+        "metadata": {
+            "client": "twelvelabs",
+            "model": model,
+            "whisper_model": None,
+            "frames_per_minute": None,
+            "duration_processed": config.get("duration"),
+            "frames_extracted": 0,
+            "frames_processed": 0,
+            "start_stage": args.start_stage,
+            "audio_language": None,
+            "transcription_successful": False
+        },
+        "transcript": None,
+        "frame_analyses": [],
+        "video_description": video_description
+    }
+
+    with open(output_dir / "analysis.json", "w") as f:
+        json.dump(results, f, indent=2)
+
+    logger.info("\nVideo Description:")
+    logger.info(video_description.get("response", "No description generated"))
+    logger.info(f"Analysis complete. Results saved to {output_dir / 'analysis.json'}")
+
 
 def main():
     parser = argparse.ArgumentParser(description="Analyze video using Vision models")
@@ -63,7 +113,7 @@ def main():
     parser.add_argument("--config", type=str, default="config",
                         help="Path to configuration directory")
     parser.add_argument("--output", type=str, help="Output directory for analysis results")
-    parser.add_argument("--client", type=str, help="Client to use (ollama or openrouter)")
+    parser.add_argument("--client", type=str, help="Client to use (ollama, openai_api, or twelvelabs)")
     parser.add_argument("--ollama-url", type=str, help="URL for the Ollama service")
     parser.add_argument("--api-key", type=str, help="API key for OpenAI-compatible service")
     parser.add_argument("--api-url", type=str, help="API URL for OpenAI-compatible API")
@@ -103,14 +153,20 @@ def main():
     output_dir = Path(config.get("output_dir"))
     client = create_client(config)
     model = get_model(config)
+    client_type = config.get("clients", {}).get("default", "ollama")
     prompt_loader = PromptLoader(config.get("prompt_dir"), config.get("prompts", []))
-    
+
+    # TwelveLabs' Pegasus model ingests the whole video in one call, so it
+    # bypasses the frame-extraction / transcription / reconstruction pipeline.
+    if client_type == "twelvelabs":
+        return run_twelvelabs(args, config, client, model, output_dir)
+
     try:
         transcript = None
         frames = []
         frame_analyses = []
         video_description = None
-        
+
         # Stage 1: Frame and Audio Processing
         if args.start_stage <= 1:
             # Initialize audio processor and extract transcript, the AudioProcessor accept following parameters that can be set in config.json:

--- a/video_analyzer/clients/twelvelabs.py
+++ b/video_analyzer/clients/twelvelabs.py
@@ -1,0 +1,118 @@
+import base64
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+from .llm_client import LLMClient
+
+logger = logging.getLogger(__name__)
+
+# Pegasus enforces a max_tokens floor; requests below this are rejected.
+MIN_MAX_TOKENS = 512
+
+
+class TwelveLabsClient(LLMClient):
+    """Client for TwelveLabs' Pegasus video understanding model.
+
+    Unlike the frame-by-frame vision clients (Ollama / OpenAI-compatible),
+    Pegasus natively ingests an entire video and reasons jointly over its
+    visuals, motion, and audio. This collapses the project's three-stage
+    frame-extraction + transcription + reconstruction pipeline into a single
+    ``analyze`` call, so no local frame sampling or Whisper transcription is
+    required when this client is selected.
+
+    The whole-video entry point is :meth:`analyze_video`. ``generate`` is
+    implemented for interface compatibility but Pegasus does not analyze
+    individual still frames, so it raises ``NotImplementedError``.
+    """
+
+    def __init__(self, api_key: str, model: str = "pegasus1.5"):
+        if not api_key:
+            raise ValueError("API key is required when using the TwelveLabs client")
+        # Imported lazily so the dependency is only needed when this client is used.
+        try:
+            from twelvelabs import TwelveLabs
+        except ImportError as e:
+            raise ImportError(
+                "The 'twelvelabs' package is required to use the TwelveLabs client. "
+                "Install it with: pip install twelvelabs"
+            ) from e
+        self.client = TwelveLabs(api_key=api_key)
+        self.model = model
+
+    @staticmethod
+    def _is_url(video: str) -> bool:
+        parsed = urlparse(str(video))
+        return parsed.scheme in ("http", "https")
+
+    def _build_video_context(self, video: str):
+        """Build a Pegasus VideoContext from a local file path or a public URL."""
+        from twelvelabs.types.video_context import (
+            VideoContext_Base64String,
+            VideoContext_Url,
+        )
+
+        if self._is_url(video):
+            logger.debug("Using remote video URL for TwelveLabs analysis")
+            return VideoContext_Url(url=video)
+
+        path = Path(video)
+        if not path.exists():
+            raise FileNotFoundError(f"Video file not found: {video}")
+        logger.debug(f"Encoding local video {path} for TwelveLabs analysis")
+        encoded = base64.b64encode(path.read_bytes()).decode("utf-8")
+        return VideoContext_Base64String(base_64_string=encoded)
+
+    def analyze_video(
+        self,
+        video: str,
+        prompt: str,
+        temperature: float = 0.2,
+        max_tokens: int = 2048,
+    ) -> Dict[str, Any]:
+        """Analyze an entire video in a single Pegasus call.
+
+        Args:
+            video: Path to a local video file or a public http(s) URL.
+                URLs are fetched server-side by TwelveLabs.
+            prompt: Natural-language instruction describing what to extract.
+            temperature: Sampling temperature for generation.
+            max_tokens: Maximum tokens in the response. Values below
+                ``MIN_MAX_TOKENS`` are raised to that floor since Pegasus
+                rejects smaller limits.
+
+        Returns:
+            Dict with a "response" key holding the generated description,
+            matching the shape returned by the other LLM clients.
+        """
+        video_context = self._build_video_context(video)
+        response = self.client.analyze(
+            model_name=self.model,
+            video=video_context,
+            prompt=prompt,
+            temperature=temperature,
+            max_tokens=max(max_tokens, MIN_MAX_TOKENS),
+        )
+        if getattr(response, "error", None):
+            raise Exception(f"TwelveLabs analysis error: {response.error}")
+        return {"response": response.data or ""}
+
+    def generate(
+        self,
+        prompt: str,
+        image_path: Optional[str] = None,
+        stream: bool = False,
+        model: str = "pegasus1.5",
+        temperature: float = 0.2,
+        num_predict: int = 256,
+    ) -> Dict[Any, Any]:
+        """Not supported: Pegasus analyzes whole videos, not single frames.
+
+        Use :meth:`analyze_video` instead. The whole-video path is wired into
+        the CLI, which bypasses per-frame analysis when this client is active.
+        """
+        raise NotImplementedError(
+            "TwelveLabsClient analyzes whole videos via analyze_video(); "
+            "it does not support per-frame generate() calls."
+        )

--- a/video_analyzer/config.py
+++ b/video_analyzer/config.py
@@ -65,10 +65,14 @@ class Config:
                 elif key == "ollama_url":
                     self.config["clients"]["ollama"]["url"] = value
                 elif key == "api_key":
-                    self.config["clients"]["openai_api"]["api_key"] = value
-                    # If key is provided but no client specified, use OpenAI API
-                    if not args.client:
-                        self.config["clients"]["default"] = "openai_api"
+                    # Route the key to the selected client (defaults to openai_api).
+                    if args.client == "twelvelabs":
+                        self.config["clients"].setdefault("twelvelabs", {})["api_key"] = value
+                    else:
+                        self.config["clients"]["openai_api"]["api_key"] = value
+                        # If key is provided but no client specified, use OpenAI API
+                        if not args.client:
+                            self.config["clients"]["default"] = "openai_api"
                 elif key == "api_url":
                     self.config["clients"]["openai_api"]["api_url"] = value
                 elif key == "model":
@@ -118,6 +122,11 @@ def get_client(config: Config) -> dict:
             "api_key": api_key,
             "api_url": api_url
         }
+    elif client_type == "twelvelabs":
+        api_key = client_config.get("api_key")
+        if not api_key:
+            raise ValueError("API key is required when using the TwelveLabs client")
+        return {"api_key": api_key}
     else:
         raise ValueError(f"Unknown client type: {client_type}")
 
@@ -125,4 +134,5 @@ def get_model(config: Config) -> str:
     """Get the appropriate model based on client type and configuration."""
     client_type = config.get("clients", {}).get("default", "ollama")
     client_config = config.get("clients", {}).get(client_type, {})
-    return client_config.get("model", "llama3.2-vision")
+    default_model = "pegasus1.5" if client_type == "twelvelabs" else "llama3.2-vision"
+    return client_config.get("model", default_model)

--- a/video_analyzer/config/default_config.json
+++ b/video_analyzer/config/default_config.json
@@ -10,6 +10,10 @@
             "api_key": "",
             "model": "meta-llama/llama-3.2-11b-vision-instruct",
             "api_url": "https://openrouter.ai/api/v1"
+        },
+        "twelvelabs": {
+            "api_key": "",
+            "model": "pegasus1.5"
         }
     },
     "prompt_dir": "prompts",


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## What this adds
An opt-in `twelvelabs` client backed by [Pegasus](https://twelvelabs.io), TwelveLabs' video understanding model. Pegasus ingests an **entire video in a single call** and reasons jointly over its visuals, motion, and audio. When this client is selected, the frame-extraction, Whisper transcription, and reconstruction stages are bypassed — Pegasus produces the description directly from the video (a local file or a public URL).

```bash
video-analyzer video.mp4 --client twelvelabs --api-key your-key
```

## Why it helps
It collapses the project's three-stage LLM + CV + ASR pipeline into one API call: no local GPU/Ollama, no Whisper download, no frame sampling. This is a fast, low-setup alternative for users who want a high-quality whole-video description, while everything that exists today stays exactly as-is.

## Opt-in / non-breaking
- New client is wired into the registry and config the same way as `ollama` and `openai_api`. Defaults are unchanged (`ollama` remains the default).
- The `twelvelabs` SDK is an **optional** dependency, imported lazily — it's only needed if you actually select this client, with a clear error message if it's missing.
- Output is written to the same `analysis.json` shape, so existing tooling/UI keeps working.

## How it was tested
- No-network unit tests for URL/path detection, empty-key handling, and the unsupported per-frame `generate()` path.
- A live end-to-end Pegasus test (gated on `TWELVELABS_API_KEY`, skipped when unset) that analyzes a public sample video and asserts a non-empty description. Verified locally against `twelvelabs==1.2.8`.
- Config resolution verified for the new client (key routing, model defaults, missing-block fallback).

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.