### PR TITLE
Document Requesty as an OpenAI-compatible provider

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -84,8 +84,8 @@ class LLMClient:
    - Returns raw response from Ollama
 
 2. Generic OpenAI API (generic_openai_api.py)
-   - Compatible with OpenAI-style APIs (OpenAI, OpenRouter, etc.)
-   - Configurable API URL (e.g. OpenRouter: https://openrouter.ai/api/v1, OpenAI: https://api.openai.com/v1)
+   - Compatible with OpenAI-style APIs (OpenAI, OpenRouter, Requesty, etc.)
+   - Configurable API URL (e.g. OpenRouter: https://openrouter.ai/api/v1, Requesty: https://router.requesty.ai/v1, OpenAI: https://api.openai.com/v1)
    - Sends images as content array with type "image_url"
    - Requires API key and service URL
    - Returns standardized response format

--- a/docs/USAGES.md
+++ b/docs/USAGES.md
@@ -16,9 +16,13 @@ This guide covers all configuration options and command line arguments for the v
 video-analyzer path/to/video.mp4
 ```
 
-### Using OpenAI-Compatible API (OpenRouter/OpenAI)
+### Using OpenAI-Compatible API (OpenRouter/Requesty/OpenAI)
 ```bash
+# OpenRouter
 video-analyzer path/to/video.mp4 --client openai_api --api-key your-key --api-url https://openrouter.ai/api/v1
+
+# Requesty
+video-analyzer path/to/video.mp4 --client openai_api --api-key your-key --api-url https://router.requesty.ai/v1 --model openai/gpt-4o-mini
 ```
 
 ## Command Line Arguments
@@ -31,7 +35,7 @@ video-analyzer path/to/video.mp4 --client openai_api --api-key your-key --api-ur
 | `--client` | Client to use (ollama or openai_api) | ollama | `--client openai_api` |
 | `--ollama-url` | URL for the Ollama service | http://localhost:11434 | `--ollama-url http://localhost:11434` |
 | `--api-key` | API key for OpenAI-compatible service | None | `--api-key sk-xxx...` |
-| `--api-url` | API URL for OpenAI-compatible API | None | `--api-url https://openrouter.ai/api/v1` |
+| `--api-url` | API URL for OpenAI-compatible API | None | `--api-url https://openrouter.ai/api/v1` (or `https://router.requesty.ai/v1`) |
 | `--model` | Name of the vision model to use | llama3.2-vision | `--model gpt-4-vision-preview` |
 | `--duration` | Duration in seconds to process | None (full video) | `--duration 60` |
 | `--keep-frames` | Keep extracted frames after analysis | False | `--keep-frames` |
@@ -195,6 +199,22 @@ video-analyzer video.mp4 \
     --api-key your-key \
     --api-url https://openrouter.ai/api/v1 \
     --model meta-llama/llama-3.2-11b-vision-instruct:free \
+    --duration 120 \
+    --whisper-model large \
+    --keep-frames \
+    --log-level DEBUG \
+    --prompt "Focus on the interactions between people"
+```
+
+### Full Configuration with Requesty
+```bash
+video-analyzer video.mp4 \
+    --config custom_config.json \
+    --output ./analysis_results \
+    --client openai_api \
+    --api-key your-key \
+    --api-url https://router.requesty.ai/v1 \
+    --model openai/gpt-4o-mini \
     --duration 120 \
     --whisper-model large \
     --keep-frames \

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ A video analysis tool that combines vision models like Llama's 11B vision model 
 
 ## Features
 - 💻 Can run completely locally - no cloud services or API keys needed
-- ☁️  Or, leverage any OpenAI API compatible LLM service (openrouter, openai, etc) for speed and scale
+- ☁️  Or, leverage any OpenAI API compatible LLM service (openrouter, requesty, openai, etc) for speed and scale
 - 🎬 Intelligent key frame extraction from videos
 - 🔊 High-quality audio transcription using OpenAI's Whisper
 - 👁️ Frame analysis using Ollama and Llama3.2 11B Vision Model
@@ -116,16 +116,20 @@ ollama serve
 
 ### OpenAI-compatible API Setup (Optional)
 
-If you want to use OpenAI-compatible APIs (like OpenRouter or OpenAI) instead of Ollama:
+If you want to use OpenAI-compatible APIs (like OpenRouter, Requesty, or OpenAI) instead of Ollama:
 
 1. Get an API key from your provider:
    - [OpenRouter](https://openrouter.ai)
+   - [Requesty](https://app.requesty.ai/api-keys)
    - [OpenAI](https://platform.openai.com)
 
 2. Configure via command line:
    ```bash
    # For OpenRouter
    video-analyzer video.mp4 --client openai_api --api-key your-key --api-url https://openrouter.ai/api/v1 --model gpt-4o
+
+   # For Requesty
+   video-analyzer video.mp4 --client openai_api --api-key your-key --api-url https://router.requesty.ai/v1 --model openai/gpt-4o-mini
 
    # For OpenAI
    video-analyzer video.mp4 --client openai_api --api-key your-key --api-url https://api.openai.com/v1 --model gpt-4o
@@ -138,13 +142,15 @@ If you want to use OpenAI-compatible APIs (like OpenRouter or OpenAI) instead of
        "default": "openai_api",
        "openai_api": {
          "api_key": "your-api-key",
-         "api_url": "https://openrouter.ai/api/v1"  # or https://api.openai.com/v1
+         "api_url": "https://openrouter.ai/api/v1"  # or https://router.requesty.ai/v1 or https://api.openai.com/v1
        }
      }
    }
    ```
 
 Note: With OpenRouter, you can use llama 3.2 11b vision for free by adding :free to the model name
+
+Note: [Requesty](https://requesty.ai) is another OpenAI-compatible router. Use the base URL `https://router.requesty.ai/v1`, authenticate with an `Authorization: Bearer` API key from [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys), and reference models in `provider/model` form (e.g. `openai/gpt-4o` or the vision-capable `openai/gpt-4o-mini`).
 
 ## Design
 For detailed information about the project's design and implementation, including how to make changes, see [docs/DESIGN.md](docs/DESIGN.md).
@@ -165,6 +171,13 @@ video-analyzer video.mp4 \
     --api-key your-key \
     --api-url https://openrouter.ai/api/v1 \
     --model meta-llama/llama-3.2-11b-vision-instruct:free
+
+# Cloud analysis with Requesty
+video-analyzer video.mp4 \
+    --client openai_api \
+    --api-key your-key \
+    --api-url https://router.requesty.ai/v1 \
+    --model openai/gpt-4o-mini
 
 # Analysis with custom prompt
 video-analyzer video.mp4 \

--- a/video_analyzer/cli.py
+++ b/video_analyzer/cli.py
@@ -66,7 +66,7 @@ def main():
     parser.add_argument("--client", type=str, help="Client to use (ollama or openrouter)")
     parser.add_argument("--ollama-url", type=str, help="URL for the Ollama service")
     parser.add_argument("--api-key", type=str, help="API key for OpenAI-compatible service")
-    parser.add_argument("--api-url", type=str, help="API URL for OpenAI-compatible API")
+    parser.add_argument("--api-url", type=str, help="API URL for OpenAI-compatible API (e.g. https://openrouter.ai/api/v1 or https://router.requesty.ai/v1)")
     parser.add_argument("--model", type=str, help="Name of the vision model to use")
     parser.add_argument("--duration", type=float, help="Duration in seconds to process")
     parser.add_argument("--keep-frames", action="store_true", help="Keep extracted frames after analysis")


### PR DESCRIPTION
Documents Requesty as an OpenAI-compatible provider option for the `openai_api` client, mirroring how OpenRouter is presented.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM router — base URL `https://router.requesty.ai/v1`, `provider/model` naming, `Authorization: Bearer` auth. Since the `openai_api` client already accepts any OpenAI-compatible `api_url`, this is a docs/config contribution (no new client class or provider enum invented, and the shipped default is unchanged).

Changes:
- `readme.md`: Requesty added to the OpenAI-compatible setup section, quick-start, and config comment (api_url `https://router.requesty.ai/v1`, key at https://app.requesty.ai/api-keys, example model `openai/gpt-4o-mini`).
- `docs/USAGES.md`, `docs/DESIGN.md`: Requesty listed alongside OpenRouter as an OpenAI-compatible endpoint.
- `video_analyzer/cli.py`: `--api-url` help mentions the Requesty base URL as an example.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.